### PR TITLE
fix employee signing

### DIFF
--- a/signing/adapter/error.go
+++ b/signing/adapter/error.go
@@ -74,7 +74,7 @@ func codeMap(code string) models.ModelErrCode {
 	case domain.ErrorCodeEmployeeManagerTooMany:
 		return models.ErrManyEmployeeManagers
 
-	case domain.ErrorCodeEmployeeManagerNotSameCorp:
+	case domain.ErrorCodeEmployeeManagerNotSameCorp, domain.ErrorCodeEmployeeNotSameCorp:
 		return models.ErrNotSameCorp
 
 	case domain.ErrorCodeEmployeeManagerAdminAsManager:

--- a/signing/domain/corp_signing.go
+++ b/signing/domain/corp_signing.go
@@ -158,6 +158,10 @@ func (cs *CorpSigning) AddEmployee(es *EmployeeSigning) error {
 		return NewDomainError(ErrorCodeEmployeeSigningNoManager)
 	}
 
+	if !cs.isSameCorp(es.Rep.EmailAddr) {
+		return NewDomainError(ErrorCodeEmployeeNotSameCorp)
+	}
+
 	for i := range cs.Employees {
 		if cs.Employees[i].isMe(es) {
 			return NewDomainError(ErrorCodeEmployeeSigningReSigning)

--- a/signing/domain/error.go
+++ b/signing/domain/error.go
@@ -29,6 +29,7 @@ const (
 	ErrorCodeEmployeeManagerNotSameCorp    = "employee_manager_not_same_corp"
 	ErrorCodeEmployeeManagerAdminAsManager = "employee_manager_admin_as_manager"
 
+	ErrorCodeEmployeeNotSameCorp         = "employee_not_same_corp"
 	ErrorCodeEmployeeSigningNotFound     = "employee_signing_not_found"
 	ErrorCodeEmployeeSigningReSigning    = "employee_signing_resigning"
 	ErrorCodeEmployeeSigningNoManager    = "employee_signing_no_manager"


### PR DESCRIPTION
1. 用户先输入一家公司的邮箱，找到对应的公司
2. 用户修改为自己的个人邮箱，获取验证码
3. 发起签署，即可正常提交签署信息

后端没有校验用户提交的邮箱是否为对应公司的邮箱域名，从而导致非公司的邮箱也能添加到公司的员工列表中