### PR TITLE
fix:修复邮件不区分大小写导致的滥发问题

### DIFF
--- a/controllers/password_retrieval.go
+++ b/controllers/password_retrieval.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"path"
+	"strings"
 
 	"github.com/beego/beego/v2/core/logs"
 
@@ -39,6 +40,8 @@ func (ctl *PasswordRetrievalController) Post() {
 		ctl.sendFailedResultAsResp(fr, action)
 		return
 	}
+	// 邮箱不区分大小写，为了防止重复发送，统一转为小写
+	info.Email = strings.ToLower(strings.TrimSpace(info.Email))
 
 	if err := (&info).Validate(); err != nil {
 		ctl.sendModelErrorAsResp(err, action)


### PR DESCRIPTION
问题：可以通过改动邮箱账号字母的大小写来多次向同一个邮箱发送验证码
修复：统一使用小写邮箱来作为验证码的接收方