### PR TITLE
feat:添加将旧社区cla签名数据迁移至新社区的功能

### DIFF
--- a/common/infrastructure/mongodb/dao.go
+++ b/common/infrastructure/mongodb/dao.go
@@ -335,6 +335,43 @@ func (impl *daoImpl) GetDocs(filter, project bson.M, result interface{}) error {
 	})
 }
 
+func (impl *daoImpl) GetDocsWithPagination(filter, project bson.M, skip, limit int, result interface{}) error {
+	return impl.withContext(func(ctx context.Context) error {
+		var cursor *mongo.Cursor
+		var err error
+
+		findOptions := &options.FindOptions{}
+		if skip > 0 {
+			findOptions.SetSkip(int64(skip))
+		}
+		if limit > 0 {
+			findOptions.SetLimit(int64(limit))
+		}
+
+		if len(project) > 0 {
+			findOptions.SetProjection(project)
+		}
+
+		cursor, err = impl.col.Find(ctx, filter, findOptions)
+		if err != nil {
+			return err
+		}
+
+		return cursor.All(ctx, result)
+	})
+}
+func (impl *daoImpl) CountDocs(filter bson.M) (int64, error) {
+	var count int64
+
+	err := impl.withContext(func(ctx context.Context) error {
+		var err error
+		count, err = impl.col.CountDocuments(ctx, filter)
+		return err
+	})
+
+	return count, err
+}
+
 func (impl *daoImpl) GetDocAndDelete(filter, project bson.M, result interface{}) error {
 	return impl.withContext(func(ctx context.Context) error {
 		var sr *mongo.SingleResult

--- a/controllers/migration.go
+++ b/controllers/migration.go
@@ -1,0 +1,40 @@
+package controllers
+
+import "github.com/opensourceways/app-cla-server/models"
+
+type MigrationController struct {
+	baseController
+}
+
+func (ctl *MigrationController) Prepare() {
+	ctl.apiPrepare(PermissionOwnerOfOrg)
+}
+
+// @Title MigrateCommunityData
+// @Description migrate CLA data from old community to new community
+// @Tags Migration
+// @Accept json
+// @Param body body models.CommunityMigrationOpt true "migration options"
+// @Success 200 {object} controllers.respData
+// @router / [post]
+func (ctl *MigrationController) MigrateCommunityData() {
+	action := "migrate community CLA data"
+
+	pl, fr := ctl.tokenPayloadBasedOnCorpManager()
+	if fr != nil {
+		ctl.sendFailedResultAsResp(fr, action)
+		return
+	}
+
+	input := &models.CommunityMigrationOpt{}
+	if fr := ctl.fetchInputPayload(input); fr != nil {
+		ctl.sendFailedResultAsResp(fr, action)
+		return
+	}
+
+	if err := models.MigrateCommunityData(pl.UserId, input); err != nil {
+		ctl.sendModelErrorAsResp(err, action)
+	} else {
+		ctl.sendSuccessResp(action, "successfully")
+	}
+}

--- a/models/adapter.go
+++ b/models/adapter.go
@@ -225,3 +225,8 @@ func GenKeyForPasswordRetrieval(opt *PasswordRetrievalKey) (string, IModelError)
 func ResetPassword(linkId string, opt *PasswordRetrieval, key string) IModelError {
 	return userAdapterInstance.ResetPassword(linkId, key, opt.Password)
 }
+
+// migration
+func MigrateCommunityData(userId string, opt *CommunityMigrationOpt) IModelError {
+	return migrationAdapterInstance.MigrateCommunityData(userId, opt)
+}

--- a/models/init.go
+++ b/models/init.go
@@ -15,6 +15,7 @@ var (
 	employeeManagerAdapterInstance   employeeManagerAdapter
 	corpEmailDomainAdapterInstance   corpEmailDomainAdapter
 	individualSigningAdapterInstance individualSigningAdapter
+	migrationAdapterInstance         migrationAdapter
 )
 
 type corpSigningAdapter interface {
@@ -144,6 +145,15 @@ type claAdapter interface {
 
 func RegisterCLAAdapter(a claAdapter) {
 	claAdapterInstance = a
+}
+
+// migrationAdapter
+type migrationAdapter interface {
+	MigrateCommunityData(userId string, opt *CommunityMigrationOpt) IModelError
+}
+
+func RegisterMigrationAdapter(a migrationAdapter) {
+	migrationAdapterInstance = a
 }
 
 // linkAdapter

--- a/models/migration.go
+++ b/models/migration.go
@@ -1,0 +1,7 @@
+package models
+
+// models/migration.go
+type CommunityMigrationOpt struct {
+	SourceLinkId string `json:"source_link_id"`
+	TargetLinkId string `json:"target_link_id"`
+}

--- a/routers/commentsRouter.go
+++ b/routers/commentsRouter.go
@@ -7,436 +7,444 @@ import (
 
 func init() {
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CLAController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CLAController"],
-        beego.ControllerComments{
-            Method: "Add",
-            Router: `/:link_id`,
-            AllowHTTPMethods: []string{"post"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CLAController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CLAController"],
+		beego.ControllerComments{
+			Method:           "Add",
+			Router:           `/:link_id`,
+			AllowHTTPMethods: []string{"post"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CLAController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CLAController"],
-        beego.ControllerComments{
-            Method: "Update",
-            Router: `/:link_id`,
-            AllowHTTPMethods: []string{"put"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CLAController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CLAController"],
+		beego.ControllerComments{
+			Method:           "Update",
+			Router:           `/:link_id`,
+			AllowHTTPMethods: []string{"put"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CLAController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CLAController"],
-        beego.ControllerComments{
-            Method: "List",
-            Router: `/:link_id`,
-            AllowHTTPMethods: []string{"get"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CLAController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CLAController"],
+		beego.ControllerComments{
+			Method:           "List",
+			Router:           `/:link_id`,
+			AllowHTTPMethods: []string{"get"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CLAController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CLAController"],
-        beego.ControllerComments{
-            Method: "Delete",
-            Router: `/:link_id/:id`,
-            AllowHTTPMethods: []string{"delete"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CLAController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CLAController"],
+		beego.ControllerComments{
+			Method:           "Delete",
+			Router:           `/:link_id/:id`,
+			AllowHTTPMethods: []string{"delete"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CLAController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CLAController"],
-        beego.ControllerComments{
-            Method: "DownloadPDF",
-            Router: `/:link_id/:id`,
-            AllowHTTPMethods: []string{"get"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CLAController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CLAController"],
+		beego.ControllerComments{
+			Method:           "DownloadPDF",
+			Router:           `/:link_id/:id`,
+			AllowHTTPMethods: []string{"get"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CLAController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CLAController"],
-        beego.ControllerComments{
-            Method: "DownloadDiffPDF",
-            Router: `/individual/diff/:link_id/:email`,
-            AllowHTTPMethods: []string{"get"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CLAController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CLAController"],
+		beego.ControllerComments{
+			Method:           "DownloadDiffPDF",
+			Router:           `/individual/diff/:link_id/:email`,
+			AllowHTTPMethods: []string{"get"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorpEmailDomainController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorpEmailDomainController"],
-        beego.ControllerComments{
-            Method: "Add",
-            Router: `/`,
-            AllowHTTPMethods: []string{"post"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorpEmailDomainController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorpEmailDomainController"],
+		beego.ControllerComments{
+			Method:           "Add",
+			Router:           `/`,
+			AllowHTTPMethods: []string{"post"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorpEmailDomainController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorpEmailDomainController"],
-        beego.ControllerComments{
-            Method: "GetAll",
-            Router: `/`,
-            AllowHTTPMethods: []string{"get"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorpEmailDomainController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorpEmailDomainController"],
+		beego.ControllerComments{
+			Method:           "GetAll",
+			Router:           `/`,
+			AllowHTTPMethods: []string{"get"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorpEmailDomainController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorpEmailDomainController"],
-        beego.ControllerComments{
-            Method: "Verify",
-            Router: `/code`,
-            AllowHTTPMethods: []string{"post"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorpEmailDomainController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorpEmailDomainController"],
+		beego.ControllerComments{
+			Method:           "Verify",
+			Router:           `/code`,
+			AllowHTTPMethods: []string{"post"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationManagerController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationManagerController"],
-        beego.ControllerComments{
-            Method: "ChangePassword",
-            Router: `/`,
-            AllowHTTPMethods: []string{"put"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationManagerController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationManagerController"],
+		beego.ControllerComments{
+			Method:           "ChangePassword",
+			Router:           `/`,
+			AllowHTTPMethods: []string{"put"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationManagerController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationManagerController"],
-        beego.ControllerComments{
-            Method: "GetBasicInfo",
-            Router: `/`,
-            AllowHTTPMethods: []string{"get"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationManagerController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationManagerController"],
+		beego.ControllerComments{
+			Method:           "GetBasicInfo",
+			Router:           `/`,
+			AllowHTTPMethods: []string{"get"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationManagerController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationManagerController"],
-        beego.ControllerComments{
-            Method: "AddCorpAdmin",
-            Router: `/:link_id/:signing_id`,
-            AllowHTTPMethods: []string{"post"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationManagerController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationManagerController"],
+		beego.ControllerComments{
+			Method:           "AddCorpAdmin",
+			Router:           `/:link_id/:signing_id`,
+			AllowHTTPMethods: []string{"post"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationManagerController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationManagerController"],
-        beego.ControllerComments{
-            Method: "Logout",
-            Router: `/auth`,
-            AllowHTTPMethods: []string{"put"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationManagerController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationManagerController"],
+		beego.ControllerComments{
+			Method:           "Logout",
+			Router:           `/auth`,
+			AllowHTTPMethods: []string{"put"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationManagerController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationManagerController"],
-        beego.ControllerComments{
-            Method: "Login",
-            Router: `/auth`,
-            AllowHTTPMethods: []string{"post"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationManagerController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationManagerController"],
+		beego.ControllerComments{
+			Method:           "Login",
+			Router:           `/auth`,
+			AllowHTTPMethods: []string{"post"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationPDFController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationPDFController"],
-        beego.ControllerComments{
-            Method: "Review",
-            Router: `/`,
-            AllowHTTPMethods: []string{"get"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationPDFController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationPDFController"],
+		beego.ControllerComments{
+			Method:           "Review",
+			Router:           `/`,
+			AllowHTTPMethods: []string{"get"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationPDFController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationPDFController"],
-        beego.ControllerComments{
-            Method: "Upload",
-            Router: `/:link_id/:signing_id`,
-            AllowHTTPMethods: []string{"post"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationPDFController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationPDFController"],
+		beego.ControllerComments{
+			Method:           "Upload",
+			Router:           `/:link_id/:signing_id`,
+			AllowHTTPMethods: []string{"post"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationPDFController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationPDFController"],
-        beego.ControllerComments{
-            Method: "Download",
-            Router: `/:link_id/:signing_id`,
-            AllowHTTPMethods: []string{"get"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationPDFController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationPDFController"],
+		beego.ControllerComments{
+			Method:           "Download",
+			Router:           `/:link_id/:signing_id`,
+			AllowHTTPMethods: []string{"get"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"],
-        beego.ControllerComments{
-            Method: "GetAll",
-            Router: `/:link_id`,
-            AllowHTTPMethods: []string{"get"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"],
+		beego.ControllerComments{
+			Method:           "GetAll",
+			Router:           `/:link_id`,
+			AllowHTTPMethods: []string{"get"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"],
-        beego.ControllerComments{
-            Method: "Sign",
-            Router: `/:link_id/`,
-            AllowHTTPMethods: []string{"post"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"],
+		beego.ControllerComments{
+			Method:           "Sign",
+			Router:           `/:link_id/`,
+			AllowHTTPMethods: []string{"post"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"],
-        beego.ControllerComments{
-            Method: "Delete",
-            Router: `/:link_id/:signing_id`,
-            AllowHTTPMethods: []string{"delete"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"],
+		beego.ControllerComments{
+			Method:           "Delete",
+			Router:           `/:link_id/:signing_id`,
+			AllowHTTPMethods: []string{"delete"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"],
-        beego.ControllerComments{
-            Method: "ResendCorpSigningEmail",
-            Router: `/:link_id/:signing_id`,
-            AllowHTTPMethods: []string{"put"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"],
+		beego.ControllerComments{
+			Method:           "ResendCorpSigningEmail",
+			Router:           `/:link_id/:signing_id`,
+			AllowHTTPMethods: []string{"put"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"],
-        beego.ControllerComments{
-            Method: "SendVerificationCode",
-            Router: `/:link_id/code`,
-            AllowHTTPMethods: []string{"post"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"],
+		beego.ControllerComments{
+			Method:           "SendVerificationCode",
+			Router:           `/:link_id/code`,
+			AllowHTTPMethods: []string{"post"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"],
-        beego.ControllerComments{
-            Method: "GetCorpInfo",
-            Router: `/:link_id/corps/:email`,
-            AllowHTTPMethods: []string{"get"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"],
+		beego.ControllerComments{
+			Method:           "GetCorpInfo",
+			Router:           `/:link_id/corps/:email`,
+			AllowHTTPMethods: []string{"get"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"],
-        beego.ControllerComments{
-            Method: "Agree",
-            Router: `/cla/agree`,
-            AllowHTTPMethods: []string{"put"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"],
+		beego.ControllerComments{
+			Method:           "Agree",
+			Router:           `/cla/agree`,
+			AllowHTTPMethods: []string{"put"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"],
-        beego.ControllerComments{
-            Method: "DownloadDiffPDF",
-            Router: `/cla/diff`,
-            AllowHTTPMethods: []string{"get"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"],
+		beego.ControllerComments{
+			Method:           "DownloadDiffPDF",
+			Router:           `/cla/diff`,
+			AllowHTTPMethods: []string{"get"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"],
-        beego.ControllerComments{
-            Method: "ListDeleted",
-            Router: `/deleted/:link_id`,
-            AllowHTTPMethods: []string{"get"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:CorporationSigningController"],
+		beego.ControllerComments{
+			Method:           "ListDeleted",
+			Router:           `/deleted/:link_id`,
+			AllowHTTPMethods: []string{"get"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:EmployeeManagerController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:EmployeeManagerController"],
-        beego.ControllerComments{
-            Method: "Post",
-            Router: `/`,
-            AllowHTTPMethods: []string{"post"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:EmployeeManagerController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:EmployeeManagerController"],
+		beego.ControllerComments{
+			Method:           "Post",
+			Router:           `/`,
+			AllowHTTPMethods: []string{"post"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:EmployeeManagerController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:EmployeeManagerController"],
-        beego.ControllerComments{
-            Method: "Delete",
-            Router: `/`,
-            AllowHTTPMethods: []string{"delete"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:EmployeeManagerController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:EmployeeManagerController"],
+		beego.ControllerComments{
+			Method:           "Delete",
+			Router:           `/`,
+			AllowHTTPMethods: []string{"delete"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:EmployeeManagerController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:EmployeeManagerController"],
-        beego.ControllerComments{
-            Method: "GetAll",
-            Router: `/`,
-            AllowHTTPMethods: []string{"get"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:EmployeeManagerController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:EmployeeManagerController"],
+		beego.ControllerComments{
+			Method:           "GetAll",
+			Router:           `/`,
+			AllowHTTPMethods: []string{"get"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:EmployeeSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:EmployeeSigningController"],
-        beego.ControllerComments{
-            Method: "GetAll",
-            Router: `/`,
-            AllowHTTPMethods: []string{"get"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:EmployeeSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:EmployeeSigningController"],
+		beego.ControllerComments{
+			Method:           "GetAll",
+			Router:           `/`,
+			AllowHTTPMethods: []string{"get"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:EmployeeSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:EmployeeSigningController"],
-        beego.ControllerComments{
-            Method: "Sign",
-            Router: `/:link_id/`,
-            AllowHTTPMethods: []string{"post"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:EmployeeSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:EmployeeSigningController"],
+		beego.ControllerComments{
+			Method:           "Sign",
+			Router:           `/:link_id/`,
+			AllowHTTPMethods: []string{"post"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:EmployeeSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:EmployeeSigningController"],
-        beego.ControllerComments{
-            Method: "SendVerificationCode",
-            Router: `/:link_id/:signing_id/code`,
-            AllowHTTPMethods: []string{"post"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:EmployeeSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:EmployeeSigningController"],
+		beego.ControllerComments{
+			Method:           "SendVerificationCode",
+			Router:           `/:link_id/:signing_id/code`,
+			AllowHTTPMethods: []string{"post"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:EmployeeSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:EmployeeSigningController"],
-        beego.ControllerComments{
-            Method: "Update",
-            Router: `/:signing_id`,
-            AllowHTTPMethods: []string{"put"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:EmployeeSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:EmployeeSigningController"],
+		beego.ControllerComments{
+			Method:           "Update",
+			Router:           `/:signing_id`,
+			AllowHTTPMethods: []string{"put"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:EmployeeSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:EmployeeSigningController"],
-        beego.ControllerComments{
-            Method: "Delete",
-            Router: `/:signing_id`,
-            AllowHTTPMethods: []string{"delete"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:EmployeeSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:EmployeeSigningController"],
+		beego.ControllerComments{
+			Method:           "Delete",
+			Router:           `/:signing_id`,
+			AllowHTTPMethods: []string{"delete"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:HeartbeatController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:HeartbeatController"],
-        beego.ControllerComments{
-            Method: "Heartbeat",
-            Router: `/`,
-            AllowHTTPMethods: []string{"get"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:HeartbeatController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:HeartbeatController"],
+		beego.ControllerComments{
+			Method:           "Heartbeat",
+			Router:           `/`,
+			AllowHTTPMethods: []string{"get"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:IndividualSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:IndividualSigningController"],
-        beego.ControllerComments{
-            Method: "Check",
-            Router: `/:link_id`,
-            AllowHTTPMethods: []string{"get"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:IndividualSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:IndividualSigningController"],
+		beego.ControllerComments{
+			Method:           "Check",
+			Router:           `/:link_id`,
+			AllowHTTPMethods: []string{"get"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:IndividualSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:IndividualSigningController"],
-        beego.ControllerComments{
-            Method: "Sign",
-            Router: `/:link_id/`,
-            AllowHTTPMethods: []string{"post"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:IndividualSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:IndividualSigningController"],
+		beego.ControllerComments{
+			Method:           "Sign",
+			Router:           `/:link_id/`,
+			AllowHTTPMethods: []string{"post"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:IndividualSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:IndividualSigningController"],
-        beego.ControllerComments{
-            Method: "Agree",
-            Router: `/:link_id/`,
-            AllowHTTPMethods: []string{"put"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:IndividualSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:IndividualSigningController"],
+		beego.ControllerComments{
+			Method:           "Agree",
+			Router:           `/:link_id/`,
+			AllowHTTPMethods: []string{"put"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:IndividualSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:IndividualSigningController"],
-        beego.ControllerComments{
-            Method: "SendVerificationCode",
-            Router: `/:link_id/code`,
-            AllowHTTPMethods: []string{"post"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:IndividualSigningController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:IndividualSigningController"],
+		beego.ControllerComments{
+			Method:           "SendVerificationCode",
+			Router:           `/:link_id/code`,
+			AllowHTTPMethods: []string{"post"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:LinkController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:LinkController"],
-        beego.ControllerComments{
-            Method: "Link",
-            Router: `/`,
-            AllowHTTPMethods: []string{"post"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:LinkController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:LinkController"],
+		beego.ControllerComments{
+			Method:           "Link",
+			Router:           `/`,
+			AllowHTTPMethods: []string{"post"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:LinkController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:LinkController"],
-        beego.ControllerComments{
-            Method: "ListLinks",
-            Router: `/`,
-            AllowHTTPMethods: []string{"get"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:LinkController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:LinkController"],
+		beego.ControllerComments{
+			Method:           "ListLinks",
+			Router:           `/`,
+			AllowHTTPMethods: []string{"get"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:LinkController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:LinkController"],
-        beego.ControllerComments{
-            Method: "Delete",
-            Router: `/:link_id`,
-            AllowHTTPMethods: []string{"delete"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:LinkController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:LinkController"],
+		beego.ControllerComments{
+			Method:           "Delete",
+			Router:           `/:link_id`,
+			AllowHTTPMethods: []string{"delete"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:LinkController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:LinkController"],
-        beego.ControllerComments{
-            Method: "Get",
-            Router: `/:link_id`,
-            AllowHTTPMethods: []string{"get"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:LinkController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:LinkController"],
+		beego.ControllerComments{
+			Method:           "Get",
+			Router:           `/:link_id`,
+			AllowHTTPMethods: []string{"get"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:LinkController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:LinkController"],
-        beego.ControllerComments{
-            Method: "GetCLAForSigning",
-            Router: `/:link_id/:apply_to`,
-            AllowHTTPMethods: []string{"get"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:LinkController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:LinkController"],
+		beego.ControllerComments{
+			Method:           "GetCLAForSigning",
+			Router:           `/:link_id/:apply_to`,
+			AllowHTTPMethods: []string{"get"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:PasswordRetrievalController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:PasswordRetrievalController"],
-        beego.ControllerComments{
-            Method: "Post",
-            Router: `/`,
-            AllowHTTPMethods: []string{"post"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:PasswordRetrievalController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:PasswordRetrievalController"],
+		beego.ControllerComments{
+			Method:           "Post",
+			Router:           `/`,
+			AllowHTTPMethods: []string{"post"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:PasswordRetrievalController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:PasswordRetrievalController"],
-        beego.ControllerComments{
-            Method: "Reset",
-            Router: `/:link_id`,
-            AllowHTTPMethods: []string{"put"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:PasswordRetrievalController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:PasswordRetrievalController"],
+		beego.ControllerComments{
+			Method:           "Reset",
+			Router:           `/:link_id`,
+			AllowHTTPMethods: []string{"put"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:SMTPController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:SMTPController"],
-        beego.ControllerComments{
-            Method: "Authorize",
-            Router: `/authorize`,
-            AllowHTTPMethods: []string{"post"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:SMTPController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:SMTPController"],
+		beego.ControllerComments{
+			Method:           "Authorize",
+			Router:           `/authorize`,
+			AllowHTTPMethods: []string{"post"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
-    beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:SMTPController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:SMTPController"],
-        beego.ControllerComments{
-            Method: "Verify",
-            Router: `/verify`,
-            AllowHTTPMethods: []string{"post"},
-            MethodParams: param.Make(),
-            Filters: nil,
-            Params: nil})
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:SMTPController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:SMTPController"],
+		beego.ControllerComments{
+			Method:           "Verify",
+			Router:           `/verify`,
+			AllowHTTPMethods: []string{"post"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 
+	beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:MigrationController"] = append(beego.GlobalControllerRouter["github.com/opensourceways/app-cla-server/controllers:MigrationController"],
+		beego.ControllerComments{
+			Method:           "MigrateCommunityData",
+			Router:           `/`,
+			AllowHTTPMethods: []string{"post"},
+			MethodParams:     param.Make(),
+			Filters:          nil,
+			Params:           nil})
 }

--- a/routers/router.go
+++ b/routers/router.go
@@ -75,6 +75,11 @@ func init() {
 				&controllers.HeartbeatController{},
 			),
 		),
+		beego.NSNamespace("/migrate",
+			beego.NSInclude(
+				&controllers.MigrationController{},
+			),
+		),
 	)
 	beego.AddNamespace(ns)
 }

--- a/signing.go
+++ b/signing.go
@@ -175,7 +175,11 @@ func initSigning(cfg *config.Config) error {
 			claAapter,
 		),
 	)
-
+	// migration
+	models.RegisterMigrationAdapter(
+		adapter.NewMigrationAdapter(
+			app.NewMigrationService(linkRepo, repo, individual, ur)),
+	)
 	// controllers
 	controllers.Init(
 		&cfg.API,

--- a/signing/adapter/migration.go
+++ b/signing/adapter/migration.go
@@ -1,0 +1,30 @@
+package adapter
+
+import (
+	"github.com/opensourceways/app-cla-server/models"
+	"github.com/opensourceways/app-cla-server/signing/app"
+)
+
+func NewMigrationAdapter(s app.MigrationService) *migrationAdapter {
+	return &migrationAdapter{
+		s: s,
+	}
+}
+
+type migrationAdapter struct {
+	s app.MigrationService
+}
+
+func (adapter *migrationAdapter) MigrateCommunityData(userId string, opt *models.CommunityMigrationOpt) models.IModelError {
+	cmd := app.CmdToMigrateCommunity{
+		UserId:       userId,
+		SourceLinkId: opt.SourceLinkId,
+		TargetLinkId: opt.TargetLinkId,
+	}
+
+	if err := adapter.s.MigrateCommunityData(&cmd); err != nil {
+		return toModelError(err)
+	}
+
+	return nil
+}

--- a/signing/app/migration.go
+++ b/signing/app/migration.go
@@ -1,0 +1,221 @@
+package app
+
+import (
+	"strings"
+
+	"github.com/beego/beego/v2/core/logs"
+	"github.com/opensourceways/app-cla-server/signing/domain"
+	"github.com/opensourceways/app-cla-server/signing/domain/repository"
+)
+
+const (
+	CorporationMigrationPageSize = 5   // 企业分页大小，可以根据实际情况调整
+	IndividualMigrationPageSize  = 100 // 个人分页大小，可以根据实际情况调整
+)
+
+type CmdToMigrateCommunity struct {
+	UserId       string
+	SourceLinkId string
+	TargetLinkId string
+}
+
+type MigrationService interface {
+	MigrateCommunityData(cmd *CmdToMigrateCommunity) error
+}
+
+func NewMigrationService(
+	linkRepo repository.Link,
+	corpRepo repository.CorpSigning,
+	individualRepo repository.IndividualSigning,
+	userRepo repository.User,
+) MigrationService {
+	return &migrationService{
+		linkRepo:       linkRepo,
+		corpRepo:       corpRepo,
+		individualRepo: individualRepo,
+		userRepo:       userRepo,
+	}
+}
+
+type migrationService struct {
+	linkRepo       repository.Link
+	corpRepo       repository.CorpSigning
+	individualRepo repository.IndividualSigning
+	userRepo       repository.User
+}
+
+func (s *migrationService) MigrateCommunityData(cmd *CmdToMigrateCommunity) error {
+	// 验证用户对两个社区都有管理权限
+	_, err := checkIfCommunityManager(cmd.UserId, cmd.SourceLinkId, s.linkRepo)
+	if err != nil {
+		return err
+	}
+
+	_, err = checkIfCommunityManager(cmd.UserId, cmd.TargetLinkId, s.linkRepo)
+	if err != nil {
+		return err
+	}
+
+	// 检查目标社区是否为空
+	if err := s.checkTargetLinkIsEmpty(cmd.TargetLinkId); err != nil {
+		return err
+	}
+
+	corpSigningIdMap := make(map[string]string)
+
+	// 1. 迁移企业签署数据
+	if err := s.migrateCorpSigningData(cmd.SourceLinkId, cmd.TargetLinkId, corpSigningIdMap); err != nil {
+		return err
+	}
+
+	// 2. 迁移个人签署数据
+	if err := s.migrateIndividualSigningData(cmd.SourceLinkId, cmd.TargetLinkId); err != nil {
+		return err
+	}
+
+	// 3. 新增：迁移用户账号信息
+	if err := s.migrateUserData(cmd.SourceLinkId, cmd.TargetLinkId, corpSigningIdMap); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *migrationService) migrateCorpSigningData(sourceLinkId, targetLinkId string, corpSigningIdMap map[string]string) error {
+	// 获取总数量
+	totalCount, err := s.corpRepo.CountByLinkId(sourceLinkId)
+	if err != nil || totalCount <= 0 {
+		return err
+	}
+
+	// 分页处理
+	for offset := 0; int64(offset) < totalCount; offset += CorporationMigrationPageSize {
+		corpSigningSummaries, err := s.corpRepo.FindAllWithPagination(sourceLinkId, offset, CorporationMigrationPageSize)
+		if err != nil {
+			return err
+		}
+		// 批量迁移当前页的数据
+		for _, summary := range corpSigningSummaries {
+			// 使用Find方法获取完整的CorpSigning对象
+			fullCorpSigning, err := s.corpRepo.Find(summary.Id)
+			if err != nil {
+				return err
+			}
+			oldId := fullCorpSigning.Id
+			// 克隆并修改LinkId
+			newCorpSigning := s.cloneCorpSigning(&fullCorpSigning, targetLinkId)
+			// 添加到新社区并修改CorpSigning.Id
+			if err := s.corpRepo.Add(&newCorpSigning); err != nil {
+				// 特别检查是否是文档已存在的错误
+				if strings.Contains(err.Error(), "doc exists") || strings.Contains(err.Error(), "document exists") {
+					logs.Error("文档已存在错误: 可能重复迁移或ID冲突, oldId=%s, newId=%s", oldId, newCorpSigning.Id)
+				}
+				return err
+			}
+			corpSigningIdMap[oldId] = newCorpSigning.Id
+		}
+		// 添加日志记录迁移进度
+		currentProgress := offset + len(corpSigningSummaries)
+		logs.Info("企业签名迁移进度: %d/%d (%.1f%%)", currentProgress, totalCount, float64(currentProgress)/float64(totalCount)*100)
+	}
+	return nil
+}
+
+func (s *migrationService) migrateIndividualSigningData(sourceLinkId, targetLinkId string) error {
+	// 获取总数量
+	totalCount, err := s.individualRepo.CountByLinkId(sourceLinkId)
+	if err != nil || totalCount <= 0 {
+		return err
+	}
+
+	// 分页处理
+	for offset := 0; int64(offset) < totalCount; offset += IndividualMigrationPageSize {
+		individualSignings, err := s.individualRepo.FindAllWithPagination(sourceLinkId, offset, IndividualMigrationPageSize)
+		if err != nil {
+			return err
+		}
+
+		// 批量迁移当前页的数据
+		for _, individualSigning := range individualSignings {
+			newIndividualSigning := s.cloneIndividualSigning(&individualSigning, targetLinkId)
+			if err := s.individualRepo.Add(&newIndividualSigning); err != nil {
+				// 特别检查是否是文档已存在的错误
+				if strings.Contains(err.Error(), "doc exists") || strings.Contains(err.Error(), "document exists") {
+					logs.Error("文档已存在错误: 可能重复迁移或ID冲突, newId=%s", individualSigning.Link.Id)
+				}
+				return err
+			}
+		}
+
+		// 添加日志记录迁移进度
+		logs.Info("Migrated %d/%d individual signings", offset+len(individualSignings), totalCount)
+	}
+
+	return nil
+}
+
+func (s *migrationService) migrateUserData(sourceLinkId, targetLinkId string, corpSigningIdMap map[string]string) error {
+	// 获取源社区的所有用户账号
+	users, err := s.userRepo.FindAllByLinkId(sourceLinkId)
+	if err != nil {
+		return err
+	}
+
+	// 为每个用户创建新的账号记录
+	for _, user := range users {
+		newUser := s.cloneUser(&user, targetLinkId, corpSigningIdMap)
+		if _, err := s.userRepo.Add(&newUser); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *migrationService) checkTargetLinkIsEmpty(targetLinkId string) error {
+	// 检查是否有企业签署
+	hasCorpSigning, err := s.corpRepo.HasSignedLink(targetLinkId)
+	if err != nil {
+		return err
+	}
+	if hasCorpSigning {
+		return domain.NewDomainError(domain.ErrorCodeLinkCanNotMigrate)
+	}
+
+	// 检查是否有个人签署
+	hasIndividualSigning, err := s.individualRepo.HasSignedLink(targetLinkId)
+	if err != nil {
+		return err
+	}
+	if hasIndividualSigning {
+		return domain.NewDomainError(domain.ErrorCodeLinkCanNotMigrate)
+	}
+
+	return nil
+}
+
+func (s *migrationService) cloneCorpSigning(original *domain.CorpSigning, newLinkId string) domain.CorpSigning {
+	clone := *original
+	// 更新LinkId到新社区
+	clone.Link.Id = newLinkId
+	clone.Link.CLAId = "0" // 清空CLAId，避免引用旧社区的CLA
+	return clone
+}
+
+func (s *migrationService) cloneIndividualSigning(original *domain.IndividualSigning, newLinkId string) domain.IndividualSigning {
+	clone := *original
+	// 更新LinkId到新社区
+	clone.Link.Id = newLinkId
+	clone.Link.CLAId = "0" // 清空CLAId，避免引用旧社区的CLA
+	return clone
+}
+
+func (s *migrationService) cloneUser(original *domain.User, newLinkId string, corpSigningIdMap map[string]string) domain.User {
+	clone := *original
+	// 更新LinkId到新社区
+	clone.LinkId = newLinkId
+	if v, ok := corpSigningIdMap[original.CorpSigningId]; ok {
+		clone.CorpSigningId = v
+	}
+	return clone
+}

--- a/signing/domain/error.go
+++ b/signing/domain/error.go
@@ -60,7 +60,8 @@ const (
 	ErrorCodeLinkNotExists    = "link_not_exists"
 	ErrorCodeLinkCanNotRemove = "link_can_not_remove"
 
-	ErrorCodeNoPermission = "no_permission"
+	ErrorCodeNoPermission      = "no_permission"
+	ErrorCodeLinkCanNotMigrate = "link_can_not_migrate"
 )
 
 // domainError

--- a/signing/domain/repository/corp_signing.go
+++ b/signing/domain/repository/corp_signing.go
@@ -34,6 +34,8 @@ type CorpSigning interface {
 	Find(string) (domain.CorpSigning, error)
 	Remove(*domain.CorpSigning) error
 	FindAll(linkId string) ([]CorpSigningSummary, error)
+	FindAllWithPagination(linkId string, offset, limit int) ([]CorpSigningSummary, error)
+	CountByLinkId(linkId string) (int64, error)
 
 	AddEmployee(*domain.CorpSigning, *domain.EmployeeSigning) error
 	SaveEmployee(*domain.CorpSigning, *domain.EmployeeSigning) error

--- a/signing/domain/repository/individual_signing.go
+++ b/signing/domain/repository/individual_signing.go
@@ -9,6 +9,9 @@ type IndividualSigning interface {
 	Add(*domain.IndividualSigning) error
 	FindSignedCLA(linkId string, email dp.EmailAddr) (string, error)
 	Find(linkId string, email dp.EmailAddr) (domain.IndividualSigning, error)
+	FindAll(LinkId string) ([]domain.IndividualSigning, error)
+	FindAllWithPagination(linkId string, offset, limit int) ([]domain.IndividualSigning, error)
+	CountByLinkId(linkId string) (int64, error)
 
 	HasSignedLink(linkId string) (bool, error)
 	HasSignedCLA(*domain.CLAIndex) (bool, error)

--- a/signing/domain/repository/user.go
+++ b/signing/domain/repository/user.go
@@ -16,4 +16,6 @@ type User interface {
 	Find(string) (domain.User, error)
 	FindByAccount(linkId string, a dp.Account) (domain.User, error)
 	FindByEmail(linkId string, e dp.EmailAddr) (domain.User, error)
+	// migration user
+	FindAllByLinkId(linkId string) ([]domain.User, error)
 }

--- a/signing/infrastructure/repositoryimpl/corp_signing.go
+++ b/signing/infrastructure/repositoryimpl/corp_signing.go
@@ -43,11 +43,11 @@ func (impl *corpSigning) Add(v *domain.CorpSigning) error {
 		},
 	}
 
-	_, err = impl.dao.InsertDocIfNotExists(docFilter, doc)
+	id, err := impl.dao.InsertDocIfNotExists(docFilter, doc)
 	if err != nil && impl.dao.IsDocExists(err) {
 		err = commonRepo.NewErrorDuplicateCreating(err)
 	}
-
+	v.Id = id
 	return err
 }
 
@@ -141,6 +141,49 @@ func (impl *corpSigning) FindAll(linkId string) ([]repository.CorpSigningSummary
 	}
 
 	return v, nil
+}
+
+func (impl *corpSigning) FindAllWithPagination(linkId string, offset, limit int) ([]repository.CorpSigningSummary, error) {
+	// 参数校验
+	if offset < 0 {
+		offset = 0
+	}
+	if limit <= 0 || limit > 1000 { // 限制最大查询数量
+		limit = 50
+	}
+	filter := linkIdFilter(linkId)
+
+	project := bson.M{
+		fieldDate:      1,
+		fieldCLAId:     1,
+		fieldLang:      1,
+		fieldRep:       1,
+		fieldCorp:      1,
+		fieldAdmin:     1,
+		fieldLinkId:    1,
+		fieldHasPDF:    1,
+		fieldCLANotify: 1,
+	}
+
+	var dos []corpSigningDO
+
+	// 使用分页查询
+	if err := impl.dao.GetDocsWithPagination(filter, project, offset, limit, &dos); err != nil {
+		return nil, err
+	}
+
+	result := make([]repository.CorpSigningSummary, len(dos))
+	for i := range dos {
+		result[i] = dos[i].toCorpSigningSummary()
+	}
+
+	return result, nil
+}
+
+func (impl *corpSigning) CountByLinkId(linkId string) (int64, error) {
+	filter := linkIdFilter(linkId)
+	filter[fieldDeleted] = bson.M{"$size": 0}
+	return impl.dao.CountDocs(filter)
 }
 
 func (impl *corpSigning) HasSignedLink(linkId string) (bool, error) {

--- a/signing/infrastructure/repositoryimpl/individual_signing.go
+++ b/signing/infrastructure/repositoryimpl/individual_signing.go
@@ -74,6 +74,46 @@ func (impl *individualSigning) Find(linkId string, email dp.EmailAddr) (domain.I
 	return do.toIndividualSigning(), nil
 }
 
+func (impl *individualSigning) FindAll(linkId string) ([]domain.IndividualSigning, error) {
+	filter := linkIdFilter(linkId)
+	filter[fieldDeleted] = false
+
+	var dos []individualSigningDO
+
+	if err := impl.dao.GetDocs(filter, nil, &dos); err != nil {
+		return nil, err
+	}
+
+	var result []domain.IndividualSigning
+	for _, do := range dos {
+		result = append(result, do.toIndividualSigning())
+	}
+
+	return result, nil
+}
+
+func (impl *individualSigning) FindAllWithPagination(linkId string, offset, limit int) ([]domain.IndividualSigning, error) {
+	filter := linkIdFilter(linkId)
+	filter[fieldDeleted] = false
+
+	var dos []individualSigningDO
+	if err := impl.dao.GetDocsWithPagination(filter, nil, offset, limit, &dos); err != nil {
+		return nil, err
+	}
+	result := make([]domain.IndividualSigning, len(dos))
+	for i := range dos {
+		result[i] = dos[i].toIndividualSigning()
+	}
+
+	return result, nil
+}
+
+func (impl *individualSigning) CountByLinkId(linkId string) (int64, error) {
+	filter := linkIdFilter(linkId)
+	filter[fieldDeleted] = false
+	return impl.dao.CountDocs(filter)
+}
+
 func (impl *individualSigning) HasSignedLink(linkId string) (bool, error) {
 	filter := linkIdFilter(linkId)
 

--- a/signing/infrastructure/repositoryimpl/mongodb.go
+++ b/signing/infrastructure/repositoryimpl/mongodb.go
@@ -44,6 +44,9 @@ type dao interface {
 
 	GetDoc(filter, project bson.M, result interface{}) error
 	GetDocs(filter, project bson.M, result interface{}) error
+	// 添加分页查询方法
+	GetDocsWithPagination(filter, project bson.M, skip, limit int, result interface{}) error
+	CountDocs(filter bson.M) (int64, error)
 	GetDocAndDelete(filter, project bson.M, result interface{}) error
 	GetArrayItem(filter bson.M, array string, filterOfArray, project bson.M, result interface{}) error
 }

--- a/signing/infrastructure/repositoryimpl/user.go
+++ b/signing/infrastructure/repositoryimpl/user.go
@@ -171,3 +171,20 @@ func (impl *user) FindByEmail(linkId string, e dp.EmailAddr) (u domain.User, err
 
 	return
 }
+
+func (impl *user) FindAllByLinkId(linkId string) ([]domain.User, error) {
+	filter := linkIdFilter(linkId)
+
+	var dos []userDO
+
+	if err := impl.dao.GetDocs(filter, nil, &dos); err != nil {
+		return nil, err
+	}
+
+	result := make([]domain.User, len(dos))
+	for i := range dos {
+		result[i] = dos[i].toUser()
+	}
+
+	return result, nil
+}


### PR DESCRIPTION
将旧链接id对应的数据clone一份，放到新社区中。之前旧社区签过cla的，新社区不需要再签，且保留之前企业创建的员工管理员等一系列原有数据。