### PR TITLE
feat:保证适配后新社区可以直接使用，无需再次签署

### DIFF
--- a/signing.go
+++ b/signing.go
@@ -178,7 +178,7 @@ func initSigning(cfg *config.Config) error {
 	// migration
 	models.RegisterMigrationAdapter(
 		adapter.NewMigrationAdapter(
-			app.NewMigrationService(linkRepo, repo, individual, ur)),
+			app.NewMigrationService(linkRepo, repo, individual, ur, cla, localCLA)),
 	)
 	// controllers
 	controllers.Init(

--- a/signing/adapter/link.go
+++ b/signing/adapter/link.go
@@ -119,9 +119,9 @@ func (adapter *linkAdatper) toFields(fields []domain.Field) []models.CLAField {
 func (adapter *linkAdatper) List(userId string) ([]models.LinkInfo, models.IModelError) {
 	v, err := adapter.s.List(userId)
 	if err != nil {
+
 		return nil, toModelError(err)
 	}
-
 	r := make([]models.LinkInfo, len(v))
 	for i := range v {
 		item := &v[i]
@@ -136,7 +136,6 @@ func (adapter *linkAdatper) List(userId string) ([]models.LinkInfo, models.IMode
 		li.ProjectURL = item.Org.ProjectURL
 		li.OrgEmailPlatform = item.Email.Platform
 	}
-
 	return r, nil
 }
 

--- a/signing/app/migration.go
+++ b/signing/app/migration.go
@@ -1,10 +1,14 @@
 package app
 
 import (
+	"os"
 	"strings"
 
 	"github.com/beego/beego/v2/core/logs"
+	commonRepo "github.com/opensourceways/app-cla-server/common/domain/repository"
 	"github.com/opensourceways/app-cla-server/signing/domain"
+	"github.com/opensourceways/app-cla-server/signing/domain/claservice"
+	"github.com/opensourceways/app-cla-server/signing/domain/localcla"
 	"github.com/opensourceways/app-cla-server/signing/domain/repository"
 )
 
@@ -28,12 +32,16 @@ func NewMigrationService(
 	corpRepo repository.CorpSigning,
 	individualRepo repository.IndividualSigning,
 	userRepo repository.User,
+	claService claservice.CLAService,
+	localCLA localcla.LocalCLA,
 ) MigrationService {
 	return &migrationService{
 		linkRepo:       linkRepo,
 		corpRepo:       corpRepo,
 		individualRepo: individualRepo,
 		userRepo:       userRepo,
+		claService:     claService,
+		localCLA:       localCLA,
 	}
 }
 
@@ -42,16 +50,18 @@ type migrationService struct {
 	corpRepo       repository.CorpSigning
 	individualRepo repository.IndividualSigning
 	userRepo       repository.User
+	claService     claservice.CLAService
+	localCLA       localcla.LocalCLA
 }
 
 func (s *migrationService) MigrateCommunityData(cmd *CmdToMigrateCommunity) error {
 	// 验证用户对两个社区都有管理权限
-	_, err := checkIfCommunityManager(cmd.UserId, cmd.SourceLinkId, s.linkRepo)
+	sourceLink, err := checkIfCommunityManager(cmd.UserId, cmd.SourceLinkId, s.linkRepo)
 	if err != nil {
 		return err
 	}
 
-	_, err = checkIfCommunityManager(cmd.UserId, cmd.TargetLinkId, s.linkRepo)
+	targetLink, err := checkIfCommunityManager(cmd.UserId, cmd.TargetLinkId, s.linkRepo)
 	if err != nil {
 		return err
 	}
@@ -61,19 +71,25 @@ func (s *migrationService) MigrateCommunityData(cmd *CmdToMigrateCommunity) erro
 		return err
 	}
 
+	// 1. 迁移 CLA 文档
+	claIdMap := make(map[string]string) // oldCLAId -> newCLAId
+	if err := s.migrateCLADocuments(sourceLink, targetLink, claIdMap); err != nil {
+		return err
+	}
+
 	corpSigningIdMap := make(map[string]string)
 
-	// 1. 迁移企业签署数据
-	if err := s.migrateCorpSigningData(cmd.SourceLinkId, cmd.TargetLinkId, corpSigningIdMap); err != nil {
+	// 2. 迁移企业签署数据（包含 PDF、email domains、managers）
+	if err := s.migrateCorpSigningData(cmd.SourceLinkId, cmd.TargetLinkId, corpSigningIdMap, claIdMap); err != nil {
 		return err
 	}
 
-	// 2. 迁移个人签署数据
-	if err := s.migrateIndividualSigningData(cmd.SourceLinkId, cmd.TargetLinkId); err != nil {
+	// 3. 迁移个人签署数据
+	if err := s.migrateIndividualSigningData(cmd.SourceLinkId, cmd.TargetLinkId, claIdMap); err != nil {
 		return err
 	}
 
-	// 3. 新增：迁移用户账号信息
+	// 4. 迁移用户账号信息
 	if err := s.migrateUserData(cmd.SourceLinkId, cmd.TargetLinkId, corpSigningIdMap); err != nil {
 		return err
 	}
@@ -81,38 +97,87 @@ func (s *migrationService) MigrateCommunityData(cmd *CmdToMigrateCommunity) erro
 	return nil
 }
 
-func (s *migrationService) migrateCorpSigningData(sourceLinkId, targetLinkId string, corpSigningIdMap map[string]string) error {
-	// 获取总数量
+func (s *migrationService) migrateCLADocuments(sourceLink, targetLink *domain.Link, claIdMap map[string]string) error {
+	logs.Info("开始迁移 CLA 文档，源社区有 %d 个 CLA", len(sourceLink.CLAs))
+	if len(sourceLink.CLAs) == 0 {
+		logs.Warning("源社区没有 CLA 文档")
+		return nil
+	}
+	// 遍历源社区的所有 CLA
+	for _, sourceCLA := range sourceLink.CLAs {
+		// 读取源 CLA 文件内容
+		sourcePath := s.localCLA.LocalPath(&domain.CLAIndex{
+			LinkId: sourceLink.Id,
+			CLAId:  sourceCLA.Id,
+		})
+
+		claText, err := os.ReadFile(sourcePath)
+		if err != nil {
+			logs.Error("Failed to read CLA file: %s, err: %v", sourcePath, err)
+			return err
+		}
+
+		// 创建新的 CLA 对象
+		newCLA := domain.CLA{
+			URL:      sourceCLA.URL,
+			Text:     claText,
+			Type:     sourceCLA.Type,
+			Language: sourceCLA.Language,
+			Fields:   sourceCLA.Fields,
+		}
+		// *** 关键修改：每次添加 CLA 前重新获取最新的 targetLink *** 在 MongoDB 更新操作中，系统使用 Version 字段实现乐观锁
+		freshTargetLink, err := s.linkRepo.Find(targetLink.Id)
+		if err != nil {
+			logs.Error("Failed to refresh target link, err: %v", err)
+			return err
+		}
+		// 添加到目标 Link
+		if err := s.claService.Add(&freshTargetLink, &newCLA); err != nil {
+			logs.Error("Failed to add CLA to target link, err: %v", err)
+			return err
+		}
+
+		// 记录 CLA ID 映射关系
+		claIdMap[sourceCLA.Id] = newCLA.Id
+
+		logs.Info("Migrated CLA: %s -> %s (type: %s, lang: %s)",
+			sourceCLA.Id, newCLA.Id, sourceCLA.Type.CLAType(), sourceCLA.Language.Language())
+	}
+
+	return nil
+}
+
+func (s *migrationService) migrateCorpSigningData(sourceLinkId, targetLinkId string, corpSigningIdMap, claIdMap map[string]string) error {
 	totalCount, err := s.corpRepo.CountByLinkId(sourceLinkId)
 	if err != nil || totalCount <= 0 {
 		return err
 	}
-
-	// 分页处理
 	for offset := 0; int64(offset) < totalCount; offset += CorporationMigrationPageSize {
 		corpSigningSummaries, err := s.corpRepo.FindAllWithPagination(sourceLinkId, offset, CorporationMigrationPageSize)
 		if err != nil {
 			return err
 		}
-		// 批量迁移当前页的数据
 		for _, summary := range corpSigningSummaries {
-			// 使用Find方法获取完整的CorpSigning对象
+			// 获取完整的CorpSigning对象
 			fullCorpSigning, err := s.corpRepo.Find(summary.Id)
 			if err != nil {
 				return err
 			}
 			oldId := fullCorpSigning.Id
-			// 克隆并修改LinkId
-			newCorpSigning := s.cloneCorpSigning(&fullCorpSigning, targetLinkId)
-			// 添加到新社区并修改CorpSigning.Id
+			newCorpSigning := s.cloneCorpSigning(&fullCorpSigning, targetLinkId, claIdMap)
 			if err := s.corpRepo.AddForMigrate(&newCorpSigning); err != nil {
-				// 特别检查是否是文档已存在的错误
 				if strings.Contains(err.Error(), "doc exists") || strings.Contains(err.Error(), "document exists") {
 					logs.Error("文档已存在错误: 可能重复迁移或ID冲突, oldId=%s, newId=%s", oldId, newCorpSigning.Id)
 				}
 				return err
 			}
 			corpSigningIdMap[oldId] = newCorpSigning.Id
+			// 迁移 PDF 文件
+			if summary.HasPDF {
+				if err := s.migrateCorpPDF(oldId, newCorpSigning.Id); err != nil {
+					logs.Error("Failed to migrate PDF for corp signing %s: %v", oldId, err)
+				}
+			}
 		}
 		// 添加日志记录迁移进度
 		currentProgress := offset + len(corpSigningSummaries)
@@ -121,7 +186,32 @@ func (s *migrationService) migrateCorpSigningData(sourceLinkId, targetLinkId str
 	return nil
 }
 
-func (s *migrationService) migrateIndividualSigningData(sourceLinkId, targetLinkId string) error {
+// 迁移企业 PDF
+func (s *migrationService) migrateCorpPDF(oldCorpSigningId, newCorpSigningId string) error {
+	pdfData, err := s.corpRepo.FindCorpPDF(oldCorpSigningId)
+	if err != nil {
+		if commonRepo.IsErrorResourceNotFound(err) {
+			return nil
+		}
+		if strings.Contains(err.Error(), "cannot decode") {
+			logs.Warning("PDF data format issue for corp signing %s, skipping: %v", oldCorpSigningId, err)
+			return nil
+		}
+		return err
+	}
+	if len(pdfData) == 0 {
+		logs.Warning("Empty PDF data for corp signing %s, skipping", oldCorpSigningId)
+		return nil
+	}
+	newCorpSigning, err := s.corpRepo.Find(newCorpSigningId)
+	if err != nil {
+		return err
+	}
+
+	return s.corpRepo.SaveCorpPDF(&newCorpSigning, pdfData)
+}
+
+func (s *migrationService) migrateIndividualSigningData(sourceLinkId, targetLinkId string, claIdMap map[string]string) error {
 	// 获取总数量
 	totalCount, err := s.individualRepo.CountByLinkId(sourceLinkId)
 	if err != nil || totalCount <= 0 {
@@ -137,8 +227,8 @@ func (s *migrationService) migrateIndividualSigningData(sourceLinkId, targetLink
 
 		// 批量迁移当前页的数据
 		for _, individualSigning := range individualSignings {
-			newIndividualSigning := s.cloneIndividualSigning(&individualSigning, targetLinkId)
-			if err := s.individualRepo.Add(&newIndividualSigning); err != nil {
+			newIndividualSigning := s.cloneIndividualSigning(&individualSigning, targetLinkId, claIdMap)
+			if err := s.individualRepo.AddForMigrate(&newIndividualSigning); err != nil {
 				// 特别检查是否是文档已存在的错误
 				if strings.Contains(err.Error(), "doc exists") || strings.Contains(err.Error(), "document exists") {
 					logs.Error("文档已存在错误: 可能重复迁移或ID冲突, newId=%s", individualSigning.Link.Id)
@@ -194,19 +284,31 @@ func (s *migrationService) checkTargetLinkIsEmpty(targetLinkId string) error {
 	return nil
 }
 
-func (s *migrationService) cloneCorpSigning(original *domain.CorpSigning, newLinkId string) domain.CorpSigning {
+func (s *migrationService) cloneCorpSigning(original *domain.CorpSigning, newLinkId string, claIdMap map[string]string) domain.CorpSigning {
 	clone := *original
+	clone.Id = ""
 	// 更新LinkId到新社区
 	clone.Link.Id = newLinkId
-	clone.Link.CLAId = "0" // 清空CLAId，避免引用旧社区的CLA
+	if v, ok := claIdMap[original.Link.CLAId]; ok {
+		clone.Link.CLAId = v
+	} else {
+		logs.Warning("CLA ID mapping not found for %s, setting to empty", original.Link.CLAId)
+		clone.Link.CLAId = ""
+	}
 	return clone
 }
 
-func (s *migrationService) cloneIndividualSigning(original *domain.IndividualSigning, newLinkId string) domain.IndividualSigning {
+func (s *migrationService) cloneIndividualSigning(original *domain.IndividualSigning, newLinkId string, claIdMap map[string]string) domain.IndividualSigning {
 	clone := *original
+	// clone.Id = ""
 	// 更新LinkId到新社区
 	clone.Link.Id = newLinkId
-	clone.Link.CLAId = "0" // 清空CLAId，避免引用旧社区的CLA
+	if v, ok := claIdMap[original.Link.CLAId]; ok {
+		clone.Link.CLAId = v
+	} else {
+		logs.Warning("CLA ID mapping not found for %s, setting to empty", original.Link.CLAId)
+		clone.Link.CLAId = "0"
+	}
 	return clone
 }
 

--- a/signing/domain/repository/individual_signing.go
+++ b/signing/domain/repository/individual_signing.go
@@ -7,6 +7,7 @@ import (
 
 type IndividualSigning interface {
 	Add(*domain.IndividualSigning) error
+	AddForMigrate(*domain.IndividualSigning) error
 	FindSignedCLA(linkId string, email dp.EmailAddr) (string, error)
 	Find(linkId string, email dp.EmailAddr) (domain.IndividualSigning, error)
 	FindAll(LinkId string) ([]domain.IndividualSigning, error)

--- a/signing/infrastructure/repositoryimpl/individual_signing.go
+++ b/signing/infrastructure/repositoryimpl/individual_signing.go
@@ -42,6 +42,26 @@ func (impl *individualSigning) Add(is *domain.IndividualSigning) error {
 	return err
 }
 
+func (impl *individualSigning) AddForMigrate(is *domain.IndividualSigning) error {
+	do := toIndividualSigningDO(is)
+	doc, err := do.toDoc()
+	if err != nil {
+		return err
+	}
+	doc[fieldVersion] = 0
+
+	filter := linkIdFilter(is.Link.Id)
+	filter[fieldEmail] = is.Rep.EmailAddr.EmailAddr()
+	filter[fieldDeleted] = false
+
+	_, err = impl.dao.InsertDocIfNotExists(filter, doc)
+	if err != nil && impl.dao.IsDocExists(err) {
+		err = commonRepo.NewErrorDuplicateCreating(err)
+	}
+
+	return err
+}
+
 func (impl *individualSigning) FindSignedCLA(linkId string, email dp.EmailAddr) (string, error) {
 	filter := linkIdFilter(linkId)
 	filter[fieldEmail] = email.EmailAddr()


### PR DESCRIPTION
社区迁移引发的需求，企业以及个人签署CLA数据同步迁移：
        // 1. 验证用户对两个社区都有管理权限
	// 2. 检查目标社区是否为空
	// 3. 迁移 CLA 文档
	// 4. 迁移企业签署数据（包含 PDF、email domains、managers）
	// 5. 迁移企业签署数据（包含 PDF、email domains、managers）
	// 6. 迁移用户账号信息
特别注意：版本要保持一致；企业同用户仓库的企业签名ID要保持一致
