### PR TITLE
feat:支持企业通过邮箱地址或者企业名称进行信息检索

### DIFF
--- a/controllers/corp_signing.go
+++ b/controllers/corp_signing.go
@@ -201,11 +201,15 @@ func (ctl *CorporationSigningController) GetAll() {
 }
 
 // @Title GetPage
-// @Description get all the corporations by page
+// @Description get all the corporations by page with search support
 // @Tags CorpSigning
 // @Accept json
-// @Param  link_id  path  string  true  "link id"
-// @Success 200 {object} models.CorporationSigningSummary
+// @Param  link_id    path  string  true  "link id"
+// @Param  page       query  int     false  "page number" default(1)
+// @Param  page_size  query  int     false  "page size" default(10)
+// @Param  admin_added query  bool    false  "filter by admin added" default(false)
+// @Param  search     query  string  false  "search query (email or corp name)"
+// @Success 200 {object} models.CorporationSigningPageSummary
 // @Failure 400 missing_url_path_parameter: missing url path parameter
 // @Failure 401 missing_token:              token is missing
 // @Failure 402 unknown_token:              token is unknown
@@ -229,12 +233,15 @@ func (ctl *CorporationSigningController) GetPage() {
 		return
 	}
 	adminAdded, sizeErr := ctl.GetBool("admin_added", false)
+	searchQuery := ctl.GetString("search") // 新增搜索参数
+
 	pl, fr := ctl.tokenPayloadBasedOnCorpManager()
 	if fr != nil {
 		ctl.sendFailedResultAsResp(fr, action)
 		return
 	}
-	if r, merr := models.ListPageCorpSigning(pl.UserId, linkID, page, pageSize, adminAdded); merr != nil {
+
+	if r, merr := models.ListPageCorpSigning(pl.UserId, linkID, page, pageSize, adminAdded, searchQuery); merr != nil {
 		ctl.sendModelErrorAsResp(merr, action)
 	} else {
 		ctl.sendSuccessResp(action, r)

--- a/models/adapter.go
+++ b/models/adapter.go
@@ -84,8 +84,8 @@ func ListCorpSigning(userId, linkID string) ([]CorporationSigningSummary, IModel
 	return corpSigningAdapterInstance.List(userId, linkID)
 }
 
-func ListPageCorpSigning(userId, linkID string, page, pageSize int, adminAdded bool) (CorporationSigningPageSummary, IModelError) {
-	return corpSigningAdapterInstance.ListPage(userId, linkID, page, pageSize, adminAdded)
+func ListPageCorpSigning(userId, linkID string, page, pageSize int, adminAdded bool, searchQuery string) (CorporationSigningPageSummary, IModelError) {
+	return corpSigningAdapterInstance.ListPage(userId, linkID, page, pageSize, adminAdded, searchQuery)
 }
 
 func GetCorpSigning(userId, csId string, email dp.EmailAddr) (string, CorporationSigning, IModelError) {

--- a/models/init.go
+++ b/models/init.go
@@ -24,7 +24,7 @@ type corpSigningAdapter interface {
 	Remove(string, string) IModelError
 	Get(userId, csId string, email dp.EmailAddr) (string, CorporationSigning, IModelError)
 	List(userId, linkId string) ([]CorporationSigningSummary, IModelError)
-	ListPage(userId, linkId string, page, pageSize int, adminAdded bool) (CorporationSigningPageSummary, IModelError)
+	ListPage(userId, linkId string, page, pageSize int, adminAdded bool, searchQuery string) (CorporationSigningPageSummary, IModelError)
 	FindCorpSummary(linkId string, email string) (interface{}, IModelError)
 	FindDiffCLAFile(signingId string) (string, IModelError)
 	Agree(signingId string) IModelError

--- a/signing/adapter/corp_signing.go
+++ b/signing/adapter/corp_signing.go
@@ -169,7 +169,7 @@ func (adapter *corpSigningAdatper) List(userId, linkId string) (
 	return r, nil
 }
 
-func (adapter *corpSigningAdatper) ListPage(userId, linkId string, page, pageSize int, adminAdded bool) (
+func (adapter *corpSigningAdatper) ListPage(userId, linkId string, page, pageSize int, adminAdded bool, searchQuery string) (
 	models.CorporationSigningPageSummary, models.IModelError,
 ) {
 	var pageData models.CorporationSigningPageSummary
@@ -177,7 +177,7 @@ func (adapter *corpSigningAdatper) ListPage(userId, linkId string, page, pageSiz
 	if page <= 0 || pageSize <= 0 {
 		return pageData, toModelError(errors.New("invalid param"))
 	}
-	v, err := adapter.s.ListPage(userId, linkId, page, pageSize, adminAdded)
+	v, err := adapter.s.ListPage(userId, linkId, page, pageSize, adminAdded, searchQuery)
 	if err != nil {
 		return pageData, toModelError(err)
 	}

--- a/signing/app/corp_signing.go
+++ b/signing/app/corp_signing.go
@@ -33,7 +33,7 @@ type CorpSigningService interface {
 	Remove(userId, csId string) error
 	Get(userId, csId string, email dp.EmailAddr) (string, CorpSigningInfoDTO, error)
 	List(userId, linkId string) ([]CorpSigningDTO, error)
-	ListPage(userId, linkId string, page, pageSize int, adminAdded bool) (CorpSigningPageDTO, error)
+	ListPage(userId, linkId string, page, pageSize int, adminAdded bool, searchQuery string) (CorpSigningPageDTO, error)
 	FindCorpSummary(cmd *CmdToFindCorpSummary) ([]CorpSummaryDTO, error)
 	FindDiffCLAFile(signingId string) (string, error)
 	AgreeWithLatestCLA(signingId string) error
@@ -147,14 +147,14 @@ func (s *corpSigningService) List(userId, linkId string) ([]CorpSigningDTO, erro
 	return dtos, nil
 }
 
-func (s *corpSigningService) ListPage(userId, linkId string, page, pageSize int, adminAdded bool) (CorpSigningPageDTO, error) {
+func (s *corpSigningService) ListPage(userId, linkId string, page, pageSize int, adminAdded bool, searchQuery string) (CorpSigningPageDTO, error) {
 	var pageData CorpSigningPageDTO
 	pageData.Total = 0
 	if _, err := checkIfCommunityManager(userId, linkId, s.linkRepo); err != nil {
 		return pageData, err
 	}
 
-	v, err := s.repo.FindPage(linkId, page, pageSize, adminAdded)
+	v, err := s.repo.FindPage(linkId, page, pageSize, adminAdded, searchQuery)
 	if err != nil || v.Total == 0 {
 		return pageData, err
 	}

--- a/signing/domain/repository/corp_signing.go
+++ b/signing/domain/repository/corp_signing.go
@@ -40,7 +40,7 @@ type CorpSigning interface {
 	Find(string) (domain.CorpSigning, error)
 	Remove(*domain.CorpSigning) error
 	FindAll(linkId string) ([]CorpSigningSummary, error)
-	FindPage(linkId string, intPage, intPageSize int, adminAdded bool) (CorpSigningSummaryPage, error)
+	FindPage(linkId string, intPage, intPageSize int, adminAdded bool, searchQuery string) (CorpSigningSummaryPage, error)
 	FindAllWithPagination(linkId string, offset, limit int) ([]CorpSigningSummary, error)
 	CountByLinkId(linkId string) (int64, error)
 

--- a/signing/infrastructure/repositoryimpl/corp_signing.go
+++ b/signing/infrastructure/repositoryimpl/corp_signing.go
@@ -212,8 +212,26 @@ func (impl *corpSigning) CountByLinkId(linkId string) (int64, error) {
 	return impl.dao.CountDocs(filter)
 }
 
-func (impl *corpSigning) FindPage(linkId string, intPage, intPageSize int, adminAdded bool) (repository.CorpSigningSummaryPage, error) {
+// 邮箱验证辅助函数
+func isEmail(query string) bool {
+	// 使用现有的邮箱验证逻辑
+	_, err := dp.NewEmailAddr(query)
+	return err == nil
+}
+
+func (impl *corpSigning) FindPage(linkId string, intPage, intPageSize int, adminAdded bool, searchQuery string) (repository.CorpSigningSummaryPage, error) {
 	filter := linkIdFilter(linkId)
+	// 添加搜索过滤条件
+	if searchQuery != "" {
+		if isEmail(searchQuery) {
+			// 按邮箱搜索
+			filter[childField(fieldRep, fieldEmail)] = searchQuery
+		} else {
+			// 按企业名称搜索（模糊匹配）
+			filter[childField(fieldCorp, fieldName)] = bson.M{"$regex": searchQuery, "$options": "i"}
+		}
+	}
+
 	if adminAdded {
 		filter["admin.id"] = bson.M{"$ne": ""}
 	} else {


### PR DESCRIPTION
需求背景：企业cla签署管理页面，新增分页功能后，数据查询时，数据检索范围仅为当前页，不支持全域检索，信息检索及确认难度大。
具体需求：申请在企业CLA签署管理系统 页面新增搜索框，且支持在全域通过邮箱地址或者企业名称进行信息搜索。