### PR TITLE
fix:修复并发条件下，token失效时间太短

### DIFF
--- a/signing/infrastructure/accesstokenimpl/config.go
+++ b/signing/infrastructure/accesstokenimpl/config.go
@@ -9,7 +9,7 @@ type Config struct {
 
 func (cfg *Config) SetDefault() {
 	if cfg.Expire <= 0 {
-		cfg.Expire = 5
+		cfg.Expire = 60
 	}
 }
 


### PR DESCRIPTION
原token在redis中存储5秒中就会失效，这时5秒内还可以用旧的token，一旦超过5秒就不能用旧的token必须得用新的，但是在并发条件下，请求响应太慢时，是不合理的，用旧的token会报失效。