### PR TITLE
feat: 无论CLA版本是否匹配都返回签署类型

### DIFF
--- a/signing/app/individual_signing.go
+++ b/signing/app/individual_signing.go
@@ -123,10 +123,8 @@ func (s *individualSigningService) FindDiffCLAFile(cmd *CmdToFindSignedCLAInfo) 
 func (s *individualSigningService) Check(cmd *CmdToCheckSinging) (dto IndividualSignedDTO, err error) {
 	f := func(claId string, t dp.CLAType) {
 		dto.Signed = true
+		dto.Type = t.CLAType()
 		dto.VersionMatched = s.cla.ContainsCla(cmd.LinkId, claId)
-		if !dto.VersionMatched {
-			dto.Type = t.CLAType()
-		}
 	}
 
 	claId, err := s.repo.FindSignedCLA(cmd.LinkId, cmd.EmailAddr)


### PR DESCRIPTION
## 变更说明

Check 接口（）的 `type` 字段现在始终返回签署类型，不再仅限于 CLA 版本过期时才返回。

| 场景 | 修改前 type | 修改后 type |
|------|------------|------------|
| 个人签署且版本最新 | "" | "individual" |
| 个人签署但版本过期 | "individual" | "individual" |
| 企业员工签署且版本最新 | "" | "corporation" |
| 企业员工签署但版本过期 | "corporation" | "corporation" |

## 影响范围

仅影响  字段，向后兼容。