### PR TITLE
feat: Check接口返回签署类型，支持未签署用户判断

### DIFF
--- a/signing/app/individual_signing.go
+++ b/signing/app/individual_signing.go
@@ -123,10 +123,8 @@ func (s *individualSigningService) FindDiffCLAFile(cmd *CmdToFindSignedCLAInfo) 
 func (s *individualSigningService) Check(cmd *CmdToCheckSinging) (dto IndividualSignedDTO, err error) {
 	f := func(claId string, t dp.CLAType) {
 		dto.Signed = true
+		dto.Type = t.CLAType()
 		dto.VersionMatched = s.cla.ContainsCla(cmd.LinkId, claId)
-		if !dto.VersionMatched {
-			dto.Type = t.CLAType()
-		}
 	}
 
 	claId, err := s.repo.FindSignedCLA(cmd.LinkId, cmd.EmailAddr)
@@ -142,18 +140,25 @@ func (s *individualSigningService) Check(cmd *CmdToCheckSinging) (dto Individual
 
 	v, err := s.corpRepo.FindEmployeesByEmail(cmd.LinkId, cmd.EmailAddr)
 	if err != nil {
-		if commonRepo.IsErrorResourceNotFound(err) {
-			err = nil
+		if !commonRepo.IsErrorResourceNotFound(err) {
+			return dto, err
 		}
+	} else if v.Enabled {
+		f(v.ClaId, dp.CLATypeCorp)
+		return
+	}
 
+	// 未签署时，检查邮箱域名是否有企业签署记录，判断应该走哪个流程
+	corps, err := s.corpRepo.FindCorpSummary(cmd.LinkId, cmd.EmailAddr.Domain())
+	if err != nil {
 		return dto, err
 	}
 
-	if !v.Enabled {
-		return dto, nil
+	if len(corps) > 0 {
+		dto.Type = dp.CLATypeCorp.CLAType()
+	} else {
+		dto.Type = dp.CLATypeIndividual.CLAType()
 	}
-
-	f(v.ClaId, dp.CLATypeCorp)
 
 	return
 }


### PR DESCRIPTION
修改Check接口逻辑：
- 已签署用户：返回实际签署类型（individual/corporation）
- 未签署用户：根据邮箱域名是否有企业签署记录判断应走哪个流程
  - 有企业签署 → type=corporation（引导走企业员工签署）
  - 无企业签署 → type=individual（引导走个人签署）

## 描述
<!-- 请简要描述这个 PR 的目的和变更内容 -->

## 相关 Issue
<!-- 链接到相关的 issue，使用关键字，如：resolve https://github.com/opensourceways/{repo}/issues/2 -->

## 变更类型
<!-- 请勾选适用的变更类型 -->
- [ ] Bug 修复
- [ ] 新功能
- [ ] 代码重构
- [ ] 文档更新
- [ ] 样式改进
- [ ] 性能优化
- [ ] 测试相关
- [ ] 其他
