### PR TITLE
feat: add Redis cache for corp signing pagination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ lastupdate.tmp
 .idea
 *.b*
 config.yaml
+CLAUDE.md

--- a/common/infrastructure/redisdb/dao.go
+++ b/common/infrastructure/redisdb/dao.go
@@ -64,3 +64,21 @@ func (cli *client) HasKey(key string) (bool, error) {
 func (impl *client) IsDocNotExists(err error) bool {
 	return errors.Is(err, errDocNotExists)
 }
+
+func (cli *client) Del(keys ...string) error {
+	return cli.withContext(func(ctx context.Context) error {
+		return cli.redisCli.Del(ctx, keys...).Err()
+	})
+}
+
+func (cli *client) Keys(pattern string) ([]string, error) {
+	var result []string
+	err := cli.withContext(func(ctx context.Context) error {
+		iter := cli.redisCli.Scan(ctx, 0, pattern, 0).Iterator()
+		for iter.Next(ctx) {
+			result = append(result, iter.Val())
+		}
+		return iter.Err()
+	})
+	return result, err
+}

--- a/signing.go
+++ b/signing.go
@@ -41,8 +41,9 @@ func initSigning(cfg *config.Config) error {
 		return err
 	}
 
-	repo := repositoryimpl.NewCorpSigning(
+	repo := repositoryimpl.NewCachedCorpSigning(
 		mongodb.DAO(cfg.Mongodb.Collections.CorpSigning),
+		redisdb.DAO(),
 	)
 
 	linkRepo := repositoryimpl.NewLink(

--- a/signing/infrastructure/repositoryimpl/corp_signing_cache.go
+++ b/signing/infrastructure/repositoryimpl/corp_signing_cache.go
@@ -57,6 +57,12 @@ func toCache(p repository.CorpSigningSummaryPage) cachedCorpSigningPage {
 	items := make([]cachedCorpSigningSummary, len(p.Data))
 	for i := range p.Data {
 		s := &p.Data[i]
+		adminName := ""
+		adminEmail := ""
+		if !s.Admin.IsEmpty() {
+			adminName = s.Admin.Representative.Name.Name()
+			adminEmail = s.Admin.Representative.EmailAddr.EmailAddr()
+		}
 		items[i] = cachedCorpSigningSummary{
 			Id:                 s.Id,
 			Date:               s.Date,
@@ -71,8 +77,8 @@ func toCache(p repository.CorpSigningSummaryPage) cachedCorpSigningPage {
 			PrimaryEmailDomain: s.Corp.PrimaryEmailDomain,
 			AllEmailDomains:    s.Corp.AllEmailDomains,
 			AdminId:            s.Admin.Id,
-			AdminName:          s.Admin.Representative.Name.Name(),
-			AdminEmail:         s.Admin.Representative.EmailAddr.EmailAddr(),
+			AdminName:          adminName,
+			AdminEmail:         adminEmail,
 		}
 	}
 	return cachedCorpSigningPage{Total: p.Total, Data: items}

--- a/signing/infrastructure/repositoryimpl/corp_signing_cache.go
+++ b/signing/infrastructure/repositoryimpl/corp_signing_cache.go
@@ -1,0 +1,330 @@
+package repositoryimpl
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/opensourceways/app-cla-server/signing/domain"
+	"github.com/opensourceways/app-cla-server/signing/domain/dp"
+	"github.com/opensourceways/app-cla-server/signing/domain/repository"
+)
+
+const (
+	corpSigningPageCacheTTL    = 5 * time.Minute
+	corpSigningPageCachePrefix = "corp_signing:page:"
+)
+
+// cacheDAO defines the Redis operations needed by the cache decorator.
+type cacheDAO interface {
+	SetWithExpiry(key string, val interface{}, expiry time.Duration) error
+	Get(key string, data interface{}) error
+	Del(keys ...string) error
+	Keys(pattern string) ([]string, error)
+	IsDocNotExists(err error) bool
+}
+
+// cachedCorpSigningPage is a serialisable snapshot of CorpSigningSummaryPage.
+type cachedCorpSigningPage struct {
+	Total int64                    `json:"total"`
+	Data  []cachedCorpSigningSummary `json:"data"`
+}
+
+type cachedCorpSigningSummary struct {
+	Id        string `json:"id"`
+	Date      string `json:"date"`
+	HasPDF    bool   `json:"has_pdf"`
+	CLANotify string `json:"cla_notify"`
+	// Link
+	LinkId   string `json:"link_id"`
+	CLAId    string `json:"cla_id"`
+	Language string `json:"language"`
+	// Rep
+	RepName  string `json:"rep_name"`
+	RepEmail string `json:"rep_email"`
+	// Corp
+	CorpName           string   `json:"corp_name"`
+	PrimaryEmailDomain string   `json:"primary_email_domain"`
+	AllEmailDomains    []string `json:"all_email_domains"`
+	// Admin
+	AdminId    string `json:"admin_id"`
+	AdminName  string `json:"admin_name"`
+	AdminEmail string `json:"admin_email"`
+}
+
+func toCache(p repository.CorpSigningSummaryPage) cachedCorpSigningPage {
+	items := make([]cachedCorpSigningSummary, len(p.Data))
+	for i := range p.Data {
+		s := &p.Data[i]
+		items[i] = cachedCorpSigningSummary{
+			Id:                 s.Id,
+			Date:               s.Date,
+			HasPDF:             s.HasPDF,
+			CLANotify:          s.CLANotify,
+			LinkId:             s.Link.Id,
+			CLAId:              s.Link.CLAId,
+			Language:           s.Link.Language.Language(),
+			RepName:            s.Rep.Name.Name(),
+			RepEmail:           s.Rep.EmailAddr.EmailAddr(),
+			CorpName:           s.Corp.Name.CorpName(),
+			PrimaryEmailDomain: s.Corp.PrimaryEmailDomain,
+			AllEmailDomains:    s.Corp.AllEmailDomains,
+			AdminId:            s.Admin.Id,
+			AdminName:          s.Admin.Representative.Name.Name(),
+			AdminEmail:         s.Admin.Representative.EmailAddr.EmailAddr(),
+		}
+	}
+	return cachedCorpSigningPage{Total: p.Total, Data: items}
+}
+
+func fromCache(c cachedCorpSigningPage) repository.CorpSigningSummaryPage {
+	items := make([]repository.CorpSigningSummary, len(c.Data))
+	for i := range c.Data {
+		s := &c.Data[i]
+		items[i] = repository.CorpSigningSummary{
+			Id:        s.Id,
+			Date:      s.Date,
+			HasPDF:    s.HasPDF,
+			CLANotify: s.CLANotify,
+			Link: domain.LinkInfo{
+				Id: s.LinkId,
+				CLAInfo: domain.CLAInfo{
+					CLAId:    s.CLAId,
+					Language: dp.CreateLanguage(s.Language),
+				},
+			},
+			Rep: domain.Representative{
+				Name:      dp.CreateName(s.RepName),
+				EmailAddr: dp.CreateEmailAddr(s.RepEmail),
+			},
+			Corp: domain.Corporation{
+				Name:               dp.CreateCorpName(s.CorpName),
+				PrimaryEmailDomain: s.PrimaryEmailDomain,
+				AllEmailDomains:    s.AllEmailDomains,
+			},
+			Admin: domain.Manager{
+				Id: s.AdminId,
+				Representative: domain.Representative{
+					Name:      dp.CreateName(s.AdminName),
+					EmailAddr: dp.CreateEmailAddr(s.AdminEmail),
+				},
+			},
+		}
+	}
+	return repository.CorpSigningSummaryPage{Total: c.Total, Data: items}
+}
+
+// pageKey builds the cache key for a specific page query.
+func pageKey(linkId string, page, pageSize int, adminAdded bool, searchQuery string) string {
+	return fmt.Sprintf("%s%s:%d:%d:%v:%s", corpSigningPageCachePrefix, linkId, page, pageSize, adminAdded, searchQuery)
+}
+
+// linkPattern returns the glob pattern to match all page cache keys for a linkId.
+func linkPattern(linkId string) string {
+	return fmt.Sprintf("%s%s:*", corpSigningPageCachePrefix, linkId)
+}
+
+// cachedCorpSigning wraps corpSigning with a Redis page cache (Decorator pattern).
+type cachedCorpSigning struct {
+	repo  *corpSigning
+	cache cacheDAO
+}
+
+// NewCachedCorpSigning wraps the base repo with a Redis cache layer.
+func NewCachedCorpSigning(dao dao, cache cacheDAO) *cachedCorpSigning {
+	return &cachedCorpSigning{
+		repo:  NewCorpSigning(dao),
+		cache: cache,
+	}
+}
+
+// FindPage tries the cache first; on miss it queries MongoDB and populates the cache.
+func (c *cachedCorpSigning) FindPage(linkId string, page, pageSize int, adminAdded bool, searchQuery string) (repository.CorpSigningSummaryPage, error) {
+	key := pageKey(linkId, page, pageSize, adminAdded, searchQuery)
+
+	// --- cache hit ---
+	var cached cachedCorpSigningPage
+	if err := c.cache.Get(key, &cached); err == nil {
+		return fromCache(cached), nil
+	}
+
+	// --- cache miss: query MongoDB ---
+	result, err := c.repo.FindPage(linkId, page, pageSize, adminAdded, searchQuery)
+	if err != nil {
+		return result, err
+	}
+
+	// populate cache asynchronously so the caller is not blocked
+	go func() {
+		payload, jsonErr := json.Marshal(toCache(result))
+		if jsonErr != nil {
+			log.Printf("corp_signing cache marshal error: %v", jsonErr)
+			return
+		}
+		if setErr := c.cache.SetWithExpiry(key, string(payload), corpSigningPageCacheTTL); setErr != nil {
+			log.Printf("corp_signing cache set error: %v", setErr)
+		}
+	}()
+
+	return result, nil
+}
+
+// invalidateLink deletes all cached pages for a given linkId.
+func (c *cachedCorpSigning) invalidateLink(linkId string) {
+	keys, err := c.cache.Keys(linkPattern(linkId))
+	if err != nil {
+		log.Printf("corp_signing cache keys error: %v", err)
+		return
+	}
+	if len(keys) == 0 {
+		return
+	}
+	if err := c.cache.Del(keys...); err != nil {
+		log.Printf("corp_signing cache invalidate error: %v", err)
+	}
+}
+
+// --- write-through: invalidate cache on every mutation ---
+
+func (c *cachedCorpSigning) Add(v *domain.CorpSigning) error {
+	err := c.repo.Add(v)
+	if err == nil {
+		go c.invalidateLink(v.Link.Id)
+	}
+	return err
+}
+
+func (c *cachedCorpSigning) AddForMigrate(v *domain.CorpSigning) error {
+	err := c.repo.AddForMigrate(v)
+	if err == nil {
+		go c.invalidateLink(v.Link.Id)
+	}
+	return err
+}
+
+func (c *cachedCorpSigning) Remove(cs *domain.CorpSigning) error {
+	err := c.repo.Remove(cs)
+	if err == nil {
+		go c.invalidateLink(cs.Link.Id)
+	}
+	return err
+}
+
+func (c *cachedCorpSigning) AddAdmin(cs *domain.CorpSigning) error {
+	err := c.repo.AddAdmin(cs)
+	if err == nil {
+		go c.invalidateLink(cs.Link.Id)
+	}
+	return err
+}
+
+func (c *cachedCorpSigning) SaveCorpPDF(cs *domain.CorpSigning, pdf []byte) error {
+	err := c.repo.SaveCorpPDF(cs, pdf)
+	if err == nil {
+		go c.invalidateLink(cs.Link.Id)
+	}
+	return err
+}
+
+func (c *cachedCorpSigning) Update(cs *domain.CorpSigning) error {
+	err := c.repo.Update(cs)
+	if err == nil {
+		go c.invalidateLink(cs.Link.Id)
+	}
+	return err
+}
+
+// --- pass-through for all other methods ---
+
+func (c *cachedCorpSigning) Find(index string) (domain.CorpSigning, error) {
+	return c.repo.Find(index)
+}
+
+func (c *cachedCorpSigning) FindAll(linkId string) ([]repository.CorpSigningSummary, error) {
+	return c.repo.FindAll(linkId)
+}
+
+func (c *cachedCorpSigning) FindAllWithPagination(linkId string, offset, limit int) ([]repository.CorpSigningSummary, error) {
+	return c.repo.FindAllWithPagination(linkId, offset, limit)
+}
+
+func (c *cachedCorpSigning) CountByLinkId(linkId string) (int64, error) {
+	return c.repo.CountByLinkId(linkId)
+}
+
+func (c *cachedCorpSigning) FindCorpSummary(linkId, emailDomain string) ([]repository.CorpSummary, error) {
+	return c.repo.FindCorpSummary(linkId, emailDomain)
+}
+
+func (c *cachedCorpSigning) FindCorpManagers(linkId, emailDomain string) ([]domain.Manager, error) {
+	return c.repo.FindCorpManagers(linkId, emailDomain)
+}
+
+func (c *cachedCorpSigning) AddEmployee(cs *domain.CorpSigning, es *domain.EmployeeSigning) error {
+	return c.repo.AddEmployee(cs, es)
+}
+
+func (c *cachedCorpSigning) SaveEmployee(cs *domain.CorpSigning, es *domain.EmployeeSigning) error {
+	return c.repo.SaveEmployee(cs, es)
+}
+
+func (c *cachedCorpSigning) FindEmployees(csId string) ([]domain.EmployeeSigning, error) {
+	return c.repo.FindEmployees(csId)
+}
+
+func (c *cachedCorpSigning) RemoveEmployee(cs *domain.CorpSigning, es *domain.EmployeeSigning) error {
+	return c.repo.RemoveEmployee(cs, es)
+}
+
+func (c *cachedCorpSigning) FindEmployeesByEmail(linkId string, email dp.EmailAddr) (repository.EmployeeSigningSummary, error) {
+	return c.repo.FindEmployeesByEmail(linkId, email)
+}
+
+func (c *cachedCorpSigning) AddEmployeeManagers(cs *domain.CorpSigning, ms []domain.Manager) error {
+	return c.repo.AddEmployeeManagers(cs, ms)
+}
+
+func (c *cachedCorpSigning) RemoveEmployeeManagers(cs *domain.CorpSigning, ms []string) error {
+	return c.repo.RemoveEmployeeManagers(cs, ms)
+}
+
+func (c *cachedCorpSigning) FindEmployeeManagers(csId string) ([]domain.Manager, error) {
+	return c.repo.FindEmployeeManagers(csId)
+}
+
+func (c *cachedCorpSigning) AddEmailDomain(cs *domain.CorpSigning, emailDomain string) error {
+	return c.repo.AddEmailDomain(cs, emailDomain)
+}
+
+func (c *cachedCorpSigning) FindEmailDomains(csId string) ([]string, error) {
+	return c.repo.FindEmailDomains(csId)
+}
+
+func (c *cachedCorpSigning) FindCorpPDF(csId string) ([]byte, error) {
+	return c.repo.FindCorpPDF(csId)
+}
+
+func (c *cachedCorpSigning) HasSignedLink(linkId string) (bool, error) {
+	return c.repo.HasSignedLink(linkId)
+}
+
+func (c *cachedCorpSigning) HasSignedCLA(index *domain.CLAIndex, t dp.CLAType) (bool, error) {
+	return c.repo.HasSignedCLA(index, t)
+}
+
+func (c *cachedCorpSigning) UpdateClaId(cs *domain.CorpSigning) error {
+	return c.repo.UpdateClaId(cs)
+}
+
+func (c *cachedCorpSigning) UpdateCLANotify(summary *repository.CorpSigningSummary) error {
+	return c.repo.UpdateCLANotify(summary)
+}
+
+func (c *cachedCorpSigning) ListTriggered() ([]TriggeredCorp, error) {
+	return c.repo.ListTriggered()
+}
+
+func (c *cachedCorpSigning) ResetTriggered(csId string, version int) error {
+	return c.repo.ResetTriggered(csId, version)
+}


### PR DESCRIPTION
## 背景

`GET /api/v1/corporation-signing/page/:link_id` 分页接口每次请求都直接查询 MongoDB，数据量大时响应慢。

## 改动

- `common/infrastructure/redisdb/dao.go` — 新增 `Del` / `Keys` 方法
- `signing/infrastructure/repositoryimpl/corp_signing_cache.go` — 装饰器模式实现 Redis 缓存层
- `signing.go` — 注入 `NewCachedCorpSigning` 替换原有 `NewCorpSigning`
- `docs/feat_add_cache.md` — 变动说明文档

## 缓存策略

- `FindPage` 先查 Redis，命中直接返回；未命中查 MongoDB 后异步写缓存，TTL 5 分钟
- `Add` / `Remove` / `AddAdmin` / `SaveCorpPDF` / `Update` 写操作后异步失效对应 linkId 的所有缓存
- Redis 不可用时自动降级到 MongoDB，不影响正常业务