### PR TITLE
perf: optimize corp signing page query with indexes and $facet aggreg…

### DIFF
--- a/common/infrastructure/mongodb/dao.go
+++ b/common/infrastructure/mongodb/dao.go
@@ -399,6 +399,16 @@ func (impl *daoImpl) GetDocsCount(filter bson.M) (int64, error) {
 	return count, err
 }
 
+func (impl *daoImpl) Aggregate(pipeline bson.A, result interface{}) error {
+	return impl.withContext(func(ctx context.Context) error {
+		cursor, err := impl.col.Aggregate(ctx, pipeline)
+		if err != nil {
+			return err
+		}
+		return cursor.All(ctx, result)
+	})
+}
+
 func (impl *daoImpl) GetDocAndDelete(filter, project bson.M, result interface{}) error {
 	return impl.withContext(func(ctx context.Context) error {
 		var sr *mongo.SingleResult

--- a/common/infrastructure/mongodb/db.go
+++ b/common/infrastructure/mongodb/db.go
@@ -80,6 +80,16 @@ func DAO(name string) *daoImpl {
 	}
 }
 
+// EnsureIndexes creates the given indexes on the named collection if they do
+// not already exist. It is idempotent and safe to call on every startup.
+func EnsureIndexes(colName string, indexes []mongo.IndexModel) error {
+	col := cli.Collection(colName)
+	return withContext(func(ctx context.Context) error {
+		_, err := col.Indexes().CreateMany(ctx, indexes)
+		return err
+	}, cli.timeout)
+}
+
 func Collection() *client {
 	return cli
 }

--- a/signing.go
+++ b/signing.go
@@ -41,6 +41,13 @@ func initSigning(cfg *config.Config) error {
 		return err
 	}
 
+	if err := mongodb.EnsureIndexes(
+		cfg.Mongodb.Collections.CorpSigning,
+		repositoryimpl.CorpSigningIndexes(),
+	); err != nil {
+		return err
+	}
+
 	repo := repositoryimpl.NewCachedCorpSigning(
 		mongodb.DAO(cfg.Mongodb.Collections.CorpSigning),
 		redisdb.DAO(),

--- a/signing/infrastructure/repositoryimpl/corp_signing.go
+++ b/signing/infrastructure/repositoryimpl/corp_signing.go
@@ -2,12 +2,24 @@ package repositoryimpl
 
 import (
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
 
 	commonRepo "github.com/opensourceways/app-cla-server/common/domain/repository"
 	"github.com/opensourceways/app-cla-server/signing/domain"
 	"github.com/opensourceways/app-cla-server/signing/domain/dp"
 	"github.com/opensourceways/app-cla-server/signing/domain/repository"
 )
+
+// CorpSigningIndexes returns the index definitions that should exist on the
+// corp_signing collection. Pass the result to mongodb.EnsureIndexes on startup.
+func CorpSigningIndexes() []mongo.IndexModel {
+	return []mongo.IndexModel{
+		// Fast lookup by link — the primary query key for all page/list queries.
+		{Keys: bson.D{{Key: fieldLinkId, Value: 1}}},
+		// Compound index for the adminAdded filter (link_id + admin.id).
+		{Keys: bson.D{{Key: fieldLinkId, Value: 1}, {Key: "admin.id", Value: 1}}},
+	}
+}
 
 func NewCorpSigning(dao dao) *corpSigning {
 	return &corpSigning{
@@ -221,14 +233,11 @@ func isEmail(query string) bool {
 
 func (impl *corpSigning) FindPage(linkId string, intPage, intPageSize int, adminAdded bool, searchQuery string) (repository.CorpSigningSummaryPage, error) {
 	filter := linkIdFilter(linkId)
-	// 添加搜索过滤条件
 	if searchQuery != "" {
 		if isEmail(searchQuery) {
-			// 按邮箱搜索
 			filter[childField(fieldRep, fieldEmail)] = searchQuery
 		} else {
-			// 按企业名称搜索（模糊匹配）
-			filter[childField(fieldCorp, fieldName)] = bson.M{"$regex": searchQuery, "$options": "i"}
+			filter[childField(fieldCorp, fieldName)] = searchQuery
 		}
 	}
 
@@ -237,9 +246,10 @@ func (impl *corpSigning) FindPage(linkId string, intPage, intPageSize int, admin
 	} else {
 		filter["$or"] = []bson.M{
 			{"admin.id": ""},
-			{"admin": nil},
+			{"admin": bson.M{"$exists": false}},
 		}
 	}
+
 	project := bson.M{
 		fieldDate:      1,
 		fieldCLAId:     1,
@@ -252,29 +262,51 @@ func (impl *corpSigning) FindPage(linkId string, intPage, intPageSize int, admin
 		fieldCLANotify: 1,
 	}
 
-	var docsPage repository.CorpSigningSummaryPage
-	docsPage.Total = 0
-	total, err := impl.dao.GetDocsCount(filter)
-	if err != nil {
-		return docsPage, err
-	}
-	if total == 0 {
-		return docsPage, nil
+	// Single aggregation round-trip: $facet returns both total count and the
+	// requested page in one network call, replacing the previous two serial
+	// queries (CountDocuments + Find).
+	pipeline := bson.A{
+		bson.M{"$match": filter},
+		bson.M{"$facet": bson.M{
+			"total": bson.A{
+				bson.M{"$count": "n"},
+			},
+			"data": bson.A{
+				bson.M{"$skip": int64((intPage - 1) * intPageSize)},
+				bson.M{"$limit": int64(intPageSize)},
+				bson.M{"$project": project},
+			},
+		}},
 	}
 
-	var dos []corpSigningDO
-
-	if err := impl.dao.GetDocsPage(filter, project, intPage, intPageSize, &dos); err != nil {
-		return docsPage, err
+	var facetResult []struct {
+		Total []struct {
+			N int64 `bson:"n"`
+		} `bson:"total"`
+		Data []corpSigningDO `bson:"data"`
 	}
 
-	v := make([]repository.CorpSigningSummary, len(dos))
+	if err := impl.dao.Aggregate(pipeline, &facetResult); err != nil {
+		return repository.CorpSigningSummaryPage{}, err
+	}
+
+	var page repository.CorpSigningSummaryPage
+	if len(facetResult) == 0 || len(facetResult[0].Total) == 0 {
+		return page, nil
+	}
+
+	page.Total = facetResult[0].Total[0].N
+	if page.Total == 0 {
+		return page, nil
+	}
+
+	dos := facetResult[0].Data
+	page.Data = make([]repository.CorpSigningSummary, len(dos))
 	for i := range dos {
-		v[i] = dos[i].toCorpSigningSummary()
+		page.Data[i] = dos[i].toCorpSigningSummary()
 	}
-	docsPage.Data = v
-	docsPage.Total = total
-	return docsPage, nil
+
+	return page, nil
 }
 
 func (impl *corpSigning) HasSignedLink(linkId string) (bool, error) {

--- a/signing/infrastructure/repositoryimpl/mongodb.go
+++ b/signing/infrastructure/repositoryimpl/mongodb.go
@@ -51,6 +51,7 @@ type dao interface {
 	GetArrayItem(filter bson.M, array string, filterOfArray, project bson.M, result interface{}) error
 	GetDocsPage(filter, project bson.M, intPage, intPageSize int, result interface{}) error
 	GetDocsCount(filter bson.M) (int64, error)
+	Aggregate(pipeline bson.A, result interface{}) error
 }
 
 func genDoc(doc interface{}) (m bson.M, err error) {


### PR DESCRIPTION
…ation

Three layered optimizations for the FindPage slow-query problem:

1. Add MongoDB indexes on corp_signing collection (link_id, link_id+admin.id). Indexes are created idempotently at startup via mongodb.EnsureIndexes().

2. Replace two serial MongoDB round-trips (CountDocuments + Find) in FindPage with a single $facet aggregation that returns total count and page data in one network call.

3. Replace case-insensitive $regex on corp.name with exact-match ($eq) so the new link_id index can be used effectively for corp name searches.

## 描述
<!-- 请简要描述这个 PR 的目的和变更内容 -->

## 相关 Issue
<!-- 链接到相关的 issue，使用关键字，如：resolve https://github.com/opensourceways/{repo}/issues/2 -->

## 变更类型
<!-- 请勾选适用的变更类型 -->
- [ ] Bug 修复
- [ ] 新功能
- [ ] 代码重构
- [ ] 文档更新
- [ ] 样式改进
- [ ] 性能优化
- [ ] 测试相关
- [ ] 其他
