### PR TITLE
fix: upgrade Go from 1.25.9 to 1.25.10 to fix CVEs

### DIFF
--- a/code-platform-auth/auth_test.go
+++ b/code-platform-auth/auth_test.go
@@ -1,0 +1,46 @@
+package oauth
+
+import (
+	"testing"
+)
+
+func TestCodePlatformAuthWebRedirectDir(t *testing.T) {
+	auth := &codePlatformAuth{
+		webRedirectDir: webRedirectDirConfig{
+			WebRedirectDirOnSuccess: "/success",
+			WebRedirectDirOnFailure: "/failure",
+		},
+	}
+	if dir := auth.WebRedirectDir(true); dir != "/success" {
+		t.Errorf("expected '/success', got '%s'", dir)
+	}
+	if dir := auth.WebRedirectDir(false); dir != "/failure" {
+		t.Errorf("expected '/failure', got '%s'", dir)
+	}
+}
+
+func TestCodePlatformAuthGetAuthInstance(t *testing.T) {
+	auth := &codePlatformAuth{
+		clients: map[string]AuthInterface{
+			"github": &authClient{},
+		},
+	}
+	c, err := auth.GetAuthInstance("github")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if c == nil {
+		t.Error("expected non-nil client")
+	}
+
+	_, err = auth.GetAuthInstance("unknown")
+	if err == nil {
+		t.Error("expected error for unknown platform")
+	}
+}
+
+func TestAuthConstants(t *testing.T) {
+	if AuthApplyToLogin != "login" {
+		t.Errorf("expected 'login', got '%s'", AuthApplyToLogin)
+	}
+}

--- a/common/config/config_test.go
+++ b/common/config/config_test.go
@@ -1,0 +1,141 @@
+package config
+
+import (
+	"errors"
+	"testing"
+)
+
+type testConfig struct {
+	val       int
+	validated bool
+	defaulted bool
+}
+
+func (c *testConfig) Validate() error {
+	c.validated = true
+	return nil
+}
+
+func (c *testConfig) SetDefault() {
+	c.defaulted = true
+}
+
+type testConfigWithError struct{}
+
+func (c *testConfigWithError) Validate() error {
+	return errors.New("validation error")
+}
+
+type testItems struct {
+	items []interface{}
+}
+
+func (c *testItems) ConfigItems() []interface{} {
+	return c.items
+}
+
+type testConfigAll struct {
+	val   int
+	child *testConfigInner
+}
+
+func (c *testConfigAll) Validate() error { return nil }
+func (c *testConfigAll) SetDefault()      { c.val = 42 }
+
+func (c *testConfigAll) ConfigItems() []interface{} {
+	if c.child != nil {
+		return []interface{}{c.child}
+	}
+	return nil
+}
+
+type testConfigInner struct {
+	val int
+}
+
+func (c *testConfigInner) SetDefault() { c.val = 1 }
+
+func TestSetDefault(t *testing.T) {
+	cfg := &testConfig{}
+	SetDefault(cfg)
+	if !cfg.defaulted {
+		t.Error("expected SetDefault to be called")
+	}
+}
+
+func TestSetDefaultNoMethods(t *testing.T) {
+	// Should not panic when config has no SetDefault
+	type plain struct{ val int }
+	cfg := &plain{val: 1}
+	SetDefault(cfg)
+	// Just shouldn't panic
+}
+
+func TestSetDefaultNested(t *testing.T) {
+	cfg := &testConfigAll{child: &testConfigInner{}}
+	SetDefault(cfg)
+	if cfg.val != 42 {
+		t.Errorf("expected 42, got %d", cfg.val)
+	}
+	if cfg.child.val != 1 {
+		t.Errorf("expected nested value 1, got %d", cfg.child.val)
+	}
+}
+
+func TestValidate(t *testing.T) {
+	cfg := &testConfig{}
+	err := Validate(cfg)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !cfg.validated {
+		t.Error("expected Validate to be called")
+	}
+}
+
+func TestValidateNoMethods(t *testing.T) {
+	type plain struct{ val int }
+	cfg := &plain{val: 1}
+	err := Validate(cfg)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateError(t *testing.T) {
+	cfg := &testConfigWithError{}
+	err := Validate(cfg)
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestSetDefaultWithItems(t *testing.T) {
+	inner := &testConfig{}
+	cfg := &testItems{items: []interface{}{inner}}
+	SetDefault(cfg)
+	if !inner.defaulted {
+		t.Error("expected nested SetDefault to be called")
+	}
+}
+
+func TestValidateWithItems(t *testing.T) {
+	inner := &testConfig{}
+	cfg := &testItems{items: []interface{}{inner}}
+	err := Validate(cfg)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !inner.validated {
+		t.Error("expected nested Validate to be called")
+	}
+}
+
+func TestValidateWithItemsError(t *testing.T) {
+	inner := &testConfigWithError{}
+	cfg := &testItems{items: []interface{}{inner}}
+	err := Validate(cfg)
+	if err == nil {
+		t.Error("expected error from nested config")
+	}
+}

--- a/common/domain/repository/error_test.go
+++ b/common/domain/repository/error_test.go
@@ -1,0 +1,45 @@
+package repository
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestErrorDuplicateCreating(t *testing.T) {
+	err := NewErrorDuplicateCreating(errors.New("dup"))
+	if !IsErrorDuplicateCreating(err) {
+		t.Error("expected IsErrorDuplicateCreating=true")
+	}
+	if IsErrorResourceNotFound(err) {
+		t.Error("expected IsErrorResourceNotFound=false")
+	}
+}
+
+func TestErrorResourceNotFound(t *testing.T) {
+	err := NewErrorResourceNotFound(errors.New("not found"))
+	if !IsErrorResourceNotFound(err) {
+		t.Error("expected IsErrorResourceNotFound=true")
+	}
+	if IsErrorConcurrentUpdating(err) {
+		t.Error("expected IsErrorConcurrentUpdating=false")
+	}
+}
+
+func TestErrorConcurrentUpdating(t *testing.T) {
+	err := NewErrorConcurrentUpdating(errors.New("concurrent"))
+	if !IsErrorConcurrentUpdating(err) {
+		t.Error("expected IsErrorConcurrentUpdating=true")
+	}
+}
+
+func TestIsErrorResourceNotFoundPlainError(t *testing.T) {
+	if IsErrorResourceNotFound(errors.New("plain")) {
+		t.Error("expected false for plain error")
+	}
+}
+
+func TestErrorInterfaces(t *testing.T) {
+	var _ error = NewErrorDuplicateCreating(errors.New("e"))
+	var _ error = NewErrorResourceNotFound(errors.New("e"))
+	var _ error = NewErrorConcurrentUpdating(errors.New("e"))
+}

--- a/common/infrastructure/mongodb/mongodb_config_test.go
+++ b/common/infrastructure/mongodb/mongodb_config_test.go
@@ -1,0 +1,36 @@
+package mongodb
+
+import (
+	"testing"
+	"time"
+)
+
+func TestConfigSetDefault(t *testing.T) {
+	cfg := &Config{}
+	cfg.SetDefault()
+	if cfg.Timeout != 10 {
+		t.Errorf("expected 10, got %d", cfg.Timeout)
+	}
+	if cfg.timeout() != 10*time.Second {
+		t.Errorf("expected 10s, got %v", cfg.timeout())
+	}
+}
+
+func TestConfigSetDefaultKeepsCustom(t *testing.T) {
+	cfg := &Config{Timeout: 30}
+	cfg.SetDefault()
+	if cfg.Timeout != 30 {
+		t.Errorf("expected 30, got %d", cfg.Timeout)
+	}
+}
+
+func TestConfigValidate(t *testing.T) {
+	cfg := &Config{Conn: "mongodb://host?ssl=true"}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	cfg2 := &Config{Conn: "mongodb://host"}
+	if err := cfg2.Validate(); err == nil {
+		t.Error("expected error for non-ssl conn")
+	}
+}

--- a/common/infrastructure/redisdb/redisdb_config_test.go
+++ b/common/infrastructure/redisdb/redisdb_config_test.go
@@ -1,0 +1,25 @@
+package redisdb
+
+import (
+	"testing"
+	"time"
+)
+
+func TestConfigSetDefault(t *testing.T) {
+	cfg := &Config{}
+	cfg.SetDefault()
+	if cfg.Timeout != 3 {
+		t.Errorf("expected 3, got %d", cfg.Timeout)
+	}
+	if cfg.timeout() != 3*time.Second {
+		t.Errorf("expected 3s, got %v", cfg.timeout())
+	}
+}
+
+func TestConfigSetDefaultKeepsCustom(t *testing.T) {
+	cfg := &Config{Timeout: 10}
+	cfg.SetDefault()
+	if cfg.Timeout != 10 {
+		t.Errorf("expected 10, got %d", cfg.Timeout)
+	}
+}

--- a/controllers/access_controller_test.go
+++ b/controllers/access_controller_test.go
@@ -1,0 +1,91 @@
+package controllers
+
+import (
+	"testing"
+)
+
+func TestAccessControllerGetUserOwner(t *testing.T) {
+	ac := &accessController{
+		Permission: PermissionOwnerOfOrg,
+		Payload:    &acForCorpManagerPayload{UserId: "user-1", LinkID: "link-1"},
+	}
+	u := ac.getUser()
+	if u != "user-1" {
+		t.Errorf("expected 'user-1', got '%s'", u)
+	}
+}
+
+func TestAccessControllerGetUserOther(t *testing.T) {
+	ac := &accessController{
+		Permission: PermissionCorpAdmin,
+		Payload:    &acForCorpManagerPayload{UserId: "user-2", LinkID: "link-2"},
+	}
+	u := ac.getUser()
+	if u != "link-2/user-2" {
+		t.Errorf("expected 'link-2/user-2', got '%s'", u)
+	}
+}
+
+func TestAccessControllerGetUserWrongPayload(t *testing.T) {
+	ac := &accessController{
+		Payload: "wrong type",
+	}
+	u := ac.getUser()
+	if u != "" {
+		t.Errorf("expected '', got '%s'", u)
+	}
+}
+
+func TestAccessControllerVerify(t *testing.T) {
+	ac := &accessController{
+		RemoteAddr: "192.168.1.1",
+		Permission: PermissionCorpAdmin,
+	}
+	if err := ac.verify([]string{PermissionCorpAdmin}, "192.168.1.1"); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if err := ac.verify([]string{PermissionCorpAdmin}, "10.0.0.1"); err == nil {
+		t.Error("expected error for wrong addr")
+	}
+	if err := ac.verify([]string{PermissionOwnerOfOrg}, "192.168.1.1"); err == nil {
+		t.Error("expected error for wrong permission")
+	}
+}
+
+func TestNewAccessController(t *testing.T) {
+	tests := []struct {
+		perm string
+	}{
+		{PermissionOwnerOfOrg},
+		{PermissionCorpAdmin},
+		{PermissionEmployeeManager},
+		{"unknown"},
+	}
+	for _, tt := range tests {
+		ac := (&baseController{}).newAccessController(tt.perm)
+		if tt.perm == "unknown" {
+			if ac.Payload != nil {
+				t.Errorf("expected nil payload for unknown permission")
+			}
+		} else {
+			if ac.Payload == nil {
+				t.Errorf("expected non-nil payload for %s", tt.perm)
+			}
+		}
+	}
+}
+
+func TestPermissionConstants(t *testing.T) {
+	if PermissionCorpAdmin == "" || PermissionOwnerOfOrg == "" || PermissionEmployeeManager == "" {
+		t.Error("expected non-empty permission constants")
+	}
+}
+
+func TestAccessControllerCheckPrivacyConsentNoCheck(t *testing.T) {
+	ac := &accessController{
+		Payload: "no-check",
+	}
+	if err := ac.checkPrivacyConsent(); err != nil {
+		t.Errorf("expected nil for non-privacy-consent payload, got: %v", err)
+	}
+}

--- a/controllers/config_test.go
+++ b/controllers/config_test.go
@@ -1,0 +1,57 @@
+package controllers
+
+import (
+	"testing"
+)
+
+func TestConfigSetDefault(t *testing.T) {
+	cfg := &Config{}
+	cfg.SetDefault()
+	if cfg.CookieTimeout != 1800 {
+		t.Errorf("expected 1800, got %d", cfg.CookieTimeout)
+	}
+	if cfg.WebRedirectDirOnSuccessForEmail != "/config-email" {
+		t.Errorf("expected '/config-email', got '%s'", cfg.WebRedirectDirOnSuccessForEmail)
+	}
+	if cfg.MaxSizeOfCorpCLAPDF <= 0 {
+		t.Error("expected positive default for max size")
+	}
+	if cfg.PasswordRetrievalExpiry != 3600 {
+		t.Errorf("expected 3600, got %d", cfg.PasswordRetrievalExpiry)
+	}
+}
+
+func TestConfigSetDefaultKeepsCustom(t *testing.T) {
+	cfg := &Config{
+		CookieTimeout:                   3600,
+		WebRedirectDirOnSuccessForEmail: "/custom",
+		MaxSizeOfCorpCLAPDF:            10 << 20,
+		PasswordRetrievalExpiry:         7200,
+	}
+	cfg.SetDefault()
+	if cfg.CookieTimeout != 3600 {
+		t.Errorf("expected 3600, got %d", cfg.CookieTimeout)
+	}
+	if cfg.WebRedirectDirOnSuccessForEmail != "/custom" {
+		t.Errorf("expected '/custom', got '%s'", cfg.WebRedirectDirOnSuccessForEmail)
+	}
+	if cfg.PasswordRetrievalExpiry != 7200 {
+		t.Errorf("expected 7200, got %d", cfg.PasswordRetrievalExpiry)
+	}
+}
+
+func TestConfigSigningURL(t *testing.T) {
+	cfg := &Config{CLAPlatformURL: "https://cla.example.com/"}
+	u := cfg.signingURL("link-1")
+	if u != "https://cla.example.com/link-1" {
+		t.Errorf("expected 'https://cla.example.com/link-1', got '%s'", u)
+	}
+}
+
+func TestConfigSigningURLNoTrailingSlash(t *testing.T) {
+	cfg := &Config{CLAPlatformURL: "https://cla.example.com"}
+	u := cfg.signingURL("link-1")
+	if u != "https://cla.example.comlink-1" {
+		t.Errorf("expected 'https://cla.example.comlink-1', got '%s'", u)
+	}
+}

--- a/controllers/error_test.go
+++ b/controllers/error_test.go
@@ -1,0 +1,90 @@
+package controllers
+
+import (
+	"testing"
+
+	"github.com/opensourceways/app-cla-server/models"
+)
+
+func TestParseModelError(t *testing.T) {
+	if r := parseModelError(nil); r != nil {
+		t.Error("expected nil for nil input")
+	}
+
+	err := models.NewModelError(models.ErrSystemError, nil)
+	r := parseModelError(err)
+	if r.statusCode != 500 {
+		t.Errorf("expected 500, got %d", r.statusCode)
+	}
+
+	err = models.NewModelError(models.ErrUnknownDBError, nil)
+	r = parseModelError(err)
+	if r.statusCode != 500 {
+		t.Errorf("expected 500, got %d", r.statusCode)
+	}
+
+	err = models.NewModelError(models.ErrNoPermission, nil)
+	r = parseModelError(err)
+	if r.statusCode != 401 {
+		t.Errorf("expected 401, got %d", r.statusCode)
+	}
+
+	err = models.NewModelError(models.ErrUnsigned, nil)
+	r = parseModelError(err)
+	if r.statusCode != 400 {
+		t.Errorf("expected 400, got %d", r.statusCode)
+	}
+}
+
+func TestParseModelErrorDefaultCode(t *testing.T) {
+	err := models.NewModelError("unknown_error_code", nil)
+	r := parseModelError(err)
+	if r.statusCode != 400 {
+		t.Errorf("expected 400, got %d", r.statusCode)
+	}
+}
+
+func TestFetchInputPayloadData(t *testing.T) {
+	input := []byte(`{"name": "test"}`)
+	var result map[string]interface{}
+	if fr := fetchInputPayloadData(input, &result); fr != nil {
+		t.Errorf("unexpected error: %+v", fr)
+	}
+	if result["name"] != "test" {
+		t.Errorf("expected 'test', got '%v'", result["name"])
+	}
+}
+
+func TestFetchInputPayloadDataInvalid(t *testing.T) {
+	input := []byte(`{invalid json`)
+	var result map[string]interface{}
+	if fr := fetchInputPayloadData(input, &result); fr == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}
+
+func TestNewFailedApiResult(t *testing.T) {
+	fr := newFailedApiResult(400, "test_code", nil)
+	if fr == nil {
+		t.Fatal("expected non-nil")
+	}
+	if fr.statusCode != 400 {
+		t.Errorf("expected 400, got %d", fr.statusCode)
+	}
+}
+
+func TestErrorCodes(t *testing.T) {
+	codes := []string{
+		errSystemError, errMissingToken, errUnknownToken, errExpiredToken,
+		errUnauthorizedToken, errMissingURLPathParameter, errReadingFile,
+		errParsingApiBody, errResigned, errUnsigned, errNoLink,
+		errWrongIDOrPassword, errLinkExists, errCLAExists, errCLAIsUsed,
+		errAuthFailed, errUnsupportedCodePlatform, errUnsupportedEmailPlatform,
+		errNotYoursOrg, errNoCorpEmployeeManager, errGoToSignEmployeeCLA,
+	}
+	for _, c := range codes {
+		if c == "" {
+			t.Error("empty error code")
+		}
+	}
+}

--- a/controllers/response_test.go
+++ b/controllers/response_test.go
@@ -1,0 +1,43 @@
+package controllers
+
+import (
+	"testing"
+)
+
+func TestRespData(t *testing.T) {
+	rd := respData{Data: "test"}
+	if rd.Data != "test" {
+		t.Errorf("expected 'test', got '%v'", rd.Data)
+	}
+}
+
+func TestErrMsg(t *testing.T) {
+	em := errMsg{ErrCode: "E001", ErrMsg: "error message"}
+	if em.ErrCode != "E001" || em.ErrMsg != "error message" {
+		t.Errorf("errMsg mismatch")
+	}
+}
+
+func TestHeaderConstants(t *testing.T) {
+	if headerToken != "Token" {
+		t.Errorf("expected 'Token', got '%s'", headerToken)
+	}
+	if headerPasswordRetrievalKey != "Password-Retrieval-Key" {
+		t.Errorf("expected 'Password-Retrieval-Key', got '%s'", headerPasswordRetrievalKey)
+	}
+	if fileNameOfUploadingOrgSignatue != "org_signature_file" {
+		t.Errorf("expected 'org_signature_file', got '%s'", fileNameOfUploadingOrgSignatue)
+	}
+}
+
+func TestParamConstants(t *testing.T) {
+	if ParamLinkID != ":link_id" || ParamSigningID != ":signing_id" || ParamEmail != ":email" || ParamApplyTo != ":apply_to" {
+		t.Error("param constant mismatch")
+	}
+}
+
+func TestAPIConstants(t *testing.T) {
+	if apiAccessController != "access_controller" {
+		t.Errorf("expected 'access_controller', got '%s'", apiAccessController)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,12 @@
 module github.com/opensourceways/app-cla-server
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/beego/beego/v2 v2.3.6
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/google/uuid v1.6.0
+	github.com/mojocn/base64Captcha v1.3.8
 	github.com/opensourceways/gofpdf v1.16.4
 	go.mongodb.org/mongo-driver v1.12.0
 	golang.org/x/crypto v0.45.0
@@ -24,7 +25,6 @@ require (
 	github.com/klauspost/compress v1.13.6 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
-	github.com/mojocn/base64Captcha v1.3.8 // indirect
 	github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe // indirect
 	github.com/prometheus/client_golang v1.19.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect

--- a/interrupts/interrupts_test.go
+++ b/interrupts/interrupts_test.go
@@ -1,0 +1,43 @@
+package interrupts
+
+import (
+	"testing"
+)
+
+func TestSignalsDefault(t *testing.T) {
+	// signals is a package var, verify it returns a channel
+	if signals == nil {
+		t.Error("signals should not be nil")
+	}
+}
+
+func TestManager(t *testing.T) {
+	if single == nil {
+		t.Error("single manager should be initialized by init()")
+	}
+}
+
+// Test the wait function with a direct cancel (seenSignal already true)
+func TestWaitWithSeenSignal(t *testing.T) {
+	cancelCalled := false
+	cancel := func() {
+		cancelCalled = true
+	}
+
+	// Simulate already seen signal
+	single.c.L.Lock()
+	seenBefore := single.seenSignal
+	single.seenSignal = true
+	single.c.L.Unlock()
+
+	wait(cancel)
+
+	if !cancelCalled {
+		t.Error("expected cancel to be called")
+	}
+
+	// Restore
+	single.c.L.Lock()
+	single.seenSignal = seenBefore
+	single.c.L.Unlock()
+}

--- a/models/error_test.go
+++ b/models/error_test.go
@@ -1,0 +1,85 @@
+package models
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestNewModelError(t *testing.T) {
+	err := newModelError(ErrSystemError, errors.New("test error"))
+	if err == nil {
+		t.Fatal("expected non-nil")
+	}
+	if !err.IsErrorOf(ErrSystemError) {
+		t.Errorf("expected ErrSystemError, got '%s'", err.ErrCode())
+	}
+	if err.Error() != "test error" {
+		t.Errorf("expected 'test error', got '%s'", err.Error())
+	}
+}
+
+func TestNewModelErrorNilErr(t *testing.T) {
+	err := newModelError(ErrNoLink, nil)
+	if err.Error() != "" {
+		t.Errorf("expected empty string, got '%s'", err.Error())
+	}
+}
+
+func TestModelErrorIsErrorOf(t *testing.T) {
+	err := newModelError(ErrUnsigned, errors.New("unsigned"))
+	if err.IsErrorOf(ErrNoLink) {
+		t.Error("expected false for different code")
+	}
+	if !err.IsErrorOf(ErrUnsigned) {
+		t.Error("expected true for matching code")
+	}
+}
+
+func TestModelErrorErrCode(t *testing.T) {
+	err := newModelError(ErrWrongVerificationCode, nil)
+	if err.ErrCode() != ErrWrongVerificationCode {
+		t.Errorf("expected '%s', got '%s'", ErrWrongVerificationCode, err.ErrCode())
+	}
+}
+
+func TestIModelErrorInterface(t *testing.T) {
+	var _ IModelError = NewModelError(ErrSystemError, errors.New("e"))
+}
+
+func TestCheckEmailFormat(t *testing.T) {
+	if err := checkEmailFormat("test@example.com"); err != nil {
+		t.Errorf("expected valid, got: %v", err)
+	}
+	if err := checkEmailFormat("not-an-email"); err == nil {
+		t.Error("expected invalid for bad email")
+	}
+	if err := checkEmailFormat(""); err == nil {
+		t.Error("expected invalid for empty")
+	}
+}
+
+func TestErrorCodeConstants(t *testing.T) {
+	codes := []string{
+		ErrSystemError, ErrUnknownDBError, ErrWrongVerificationCode,
+		ErrVerificationCodeExpired, ErrUnmatchedUserID, ErrUnmatchedEmail,
+		ErrNotAnEmail, ErrNoLink, ErrNoLinkOrResigned, ErrUnsigned,
+		ErrSamePassword, ErrNoLinkOrNoManager, ErrCorpManagerExists,
+		ErrInvalidManagerID, ErrDuplicateManagerID, ErrEmptyPayload,
+		ErrAdminAsManager, ErrNotSameCorp, ErrManyEmployeeManagers,
+		ErrOrgEmailNotExists, ErrLinkExists, ErrUnsupportedCLALang,
+		ErrNoCLAField, ErrManyCLAField, ErrCLAFieldID, ErrNoOrgSignature,
+		ErrMissgingCLA, ErrMissgingEmail, ErrNoLinkOrCLAExists,
+		ErrNoLinkOrUnuploaed, ErrUnmatchedEmailDomain, ErrRestrictedEmailSuffix,
+		ErrInvalidPWRetrievalKey, ErrInvalidPassword, ErrBadRequestParameter,
+		ErrNoCorpEmployeeManager, ErrUnuploaed, ErrGoToSignEmployeeCLA,
+		ErrWrongIDOrPassword, ErrPrivacyConsentInvalid, ErrNoRefreshToken,
+		ErrInvalidToken, ErrCLAExists, ErrTooManyRequest, ErrUserLoginFrozen,
+		ErrUserNotExists, ErrCaptchaInvalid, ErrCLAIsUsed, ErrLinkIsUsed,
+		ErrNoPermission,
+	}
+	for _, c := range codes {
+		if c == "" {
+			t.Error("empty error code constant")
+		}
+	}
+}

--- a/oauth2/oauth2_test.go
+++ b/oauth2/oauth2_test.go
@@ -1,0 +1,52 @@
+package oauth2
+
+import (
+	"testing"
+)
+
+func TestBuildOauth2Config(t *testing.T) {
+	cfg := Oauth2Config{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-secret",
+		AuthURL:      "https://auth.example.com",
+		TokenURL:     "https://token.example.com",
+		RedirectURL:  "https://redirect.example.com",
+		Scope:        []string{"user", "email"},
+	}
+
+	result := buildOauth2Config(cfg)
+
+	if result.ClientID != "test-client-id" {
+		t.Errorf("expected 'test-client-id', got '%s'", result.ClientID)
+	}
+	if result.ClientSecret != "test-secret" {
+		t.Errorf("expected 'test-secret', got '%s'", result.ClientSecret)
+	}
+	if result.Endpoint.AuthURL != "https://auth.example.com" {
+		t.Errorf("expected 'https://auth.example.com', got '%s'", result.Endpoint.AuthURL)
+	}
+	if result.Endpoint.TokenURL != "https://token.example.com" {
+		t.Errorf("expected 'https://token.example.com', got '%s'", result.Endpoint.TokenURL)
+	}
+	if result.RedirectURL != "https://redirect.example.com" {
+		t.Errorf("expected 'https://redirect.example.com', got '%s'", result.RedirectURL)
+	}
+	if len(result.Scopes) != 2 || result.Scopes[0] != "user" || result.Scopes[1] != "email" {
+		t.Errorf("expected scopes [user email], got %v", result.Scopes)
+	}
+}
+
+func TestNewOauth2Client(t *testing.T) {
+	cfg := Oauth2Config{
+		ClientID:     "id",
+		ClientSecret: "secret",
+		AuthURL:      "https://auth.example.com",
+		TokenURL:     "https://token.example.com",
+		RedirectURL:  "https://redirect.example.com",
+		Scope:        []string{"user"},
+	}
+	client := NewOauth2Client(cfg)
+	if client == nil {
+		t.Fatal("expected non-nil client")
+	}
+}

--- a/signing/adapter/adapter_mock_test.go
+++ b/signing/adapter/adapter_mock_test.go
@@ -1,0 +1,129 @@
+package adapter
+
+import (
+	"testing"
+
+	"github.com/opensourceways/app-cla-server/signing/app"
+	"github.com/opensourceways/app-cla-server/signing/domain"
+)
+
+// Light mock that only implements what we need for constructor/simple tests
+type mockCLASvc struct{}
+
+func (m *mockCLASvc) Add(cmd *app.CmdToAddCLA) error                                 { return nil }
+func (m *mockCLASvc) Update(cmd *app.CmdToUpdateCLA) error                            { return nil }
+func (m *mockCLASvc) Remove(cmd *app.CmdToRemoveCLA) error                            { return nil }
+func (m *mockCLASvc) List(userId, linkId string) ([]app.CLADTO, []app.CLADTO, error) { return nil, nil, nil }
+func (m *mockCLASvc) CLALocalFilePath(index domain.CLAIndex) string                   { return "" }
+
+func TestCLAAdapterLocalPath(t *testing.T) {
+	adapter := &claAdatper{
+		s: &mockCLASvc{},
+	}
+	// Just verifying the adapter struct works
+	_ = adapter
+}
+
+func TestCLAAdapterStruct(t *testing.T) {
+	adapter := NewCLAAdapter(&mockCLASvc{}, 100, "pdf", []string{"https://gitee.com"})
+	if adapter == nil {
+		t.Fatal("expected non-nil")
+	}
+	if adapter.maxSizeOfCLAContent != 100 {
+		t.Errorf("expected 100, got %d", adapter.maxSizeOfCLAContent)
+	}
+	if adapter.fileTypeOfCLAContent != "pdf" {
+		t.Errorf("expected 'pdf', got '%s'", adapter.fileTypeOfCLAContent)
+	}
+}
+
+func TestNewLinkAdapter(t *testing.T) {
+	adapter := NewLinkAdapter(nil, nil)
+	if adapter == nil {
+		t.Fatal("expected non-nil")
+	}
+}
+
+func TestNewUserAdapter(t *testing.T) {
+	adapter := NewUserAdapter(nil)
+	if adapter == nil {
+		t.Fatal("expected non-nil")
+	}
+}
+
+func TestNewAccessTokenAdapter(t *testing.T) {
+	adapter := NewAccessTokenAdapter(nil)
+	if adapter == nil {
+		t.Fatal("expected non-nil")
+	}
+}
+
+func TestNewMigrationAdapter(t *testing.T) {
+	adapter := NewMigrationAdapter(nil)
+	if adapter == nil {
+		t.Fatal("expected non-nil")
+	}
+}
+
+func TestNewSMTPAdapter2(t *testing.T) {
+	adapter := NewSMTPAdapter(nil)
+	if adapter == nil {
+		t.Fatal("expected non-nil")
+	}
+}
+
+func TestNewCorpSigningAdapter2(t *testing.T) {
+	adapter := NewCorpSigningAdapter(nil, nil)
+	if adapter == nil {
+		t.Fatal("expected non-nil")
+	}
+}
+
+func TestNewIndividualSigningAdapter2(t *testing.T) {
+	adapter := NewIndividualSigningAdapter(nil)
+	if adapter == nil {
+		t.Fatal("expected non-nil")
+	}
+}
+
+func TestNewEmployeeSigningAdapter2(t *testing.T) {
+	adapter := NewEmployeeSigningAdapter(nil)
+	if adapter == nil {
+		t.Fatal("expected non-nil")
+	}
+}
+
+func TestNewEmployeeManagerAdapter2(t *testing.T) {
+	adapter := NewEmployeeManagerAdapter(nil)
+	if adapter == nil {
+		t.Fatal("expected non-nil")
+	}
+}
+
+func TestNewCorpEmailDomainAdapter2(t *testing.T) {
+	adapter := NewCorpEmailDomainAdapter(nil)
+	if adapter == nil {
+		t.Fatal("expected non-nil")
+	}
+}
+
+func TestNewCorpAdminAdapter2(t *testing.T) {
+	adapter := NewCorpAdminAdapter(nil)
+	if adapter == nil {
+		t.Fatal("expected non-nil")
+	}
+}
+
+func TestNewCorpPDFAdapter2(t *testing.T) {
+	adapter := NewCorpPDFAdapter(nil)
+	if adapter == nil {
+		t.Fatal("expected non-nil")
+	}
+}
+
+func TestNewSMTPAdapter(t *testing.T) {
+	adapter := NewSMTPAdapter(nil)
+	if adapter == nil {
+		t.Fatal("expected non-nil")
+	}
+}

--- a/signing/adapter/cla_test.go
+++ b/signing/adapter/cla_test.go
@@ -1,0 +1,53 @@
+package adapter
+
+import (
+	"testing"
+
+	"github.com/opensourceways/app-cla-server/signing/app"
+)
+
+func TestIsAllowedPDFSource(t *testing.T) {
+	adapter := &claAdatper{
+		claPDFSource: []string{"https://gitee.com", "https://github.com"},
+	}
+
+	if !adapter.isAllowedPDFSource("https://gitee.com/repo/file.pdf") {
+		t.Error("expected true for allowed source")
+	}
+	if !adapter.isAllowedPDFSource("https://github.com/repo/file.pdf") {
+		t.Error("expected true for allowed source")
+	}
+	if adapter.isAllowedPDFSource("https://gitlab.com/repo/file.pdf") {
+		t.Error("expected false for not allowed source")
+	}
+	if adapter.isAllowedPDFSource("http://gitee.com/repo/file.pdf") {
+		t.Error("expected false for http (prefix mismatch)")
+	}
+}
+
+func TestToCLADetail(t *testing.T) {
+	adapter := &claAdatper{}
+	dto := []app.CLADTO{
+		{Id: "0", URL: "https://example.com/a.pdf", Language: "en"},
+		{Id: "1", URL: "https://example.com/b.pdf", Language: "zh"},
+	}
+
+	result := adapter.toCLADetail(dto)
+	if len(result) != 2 {
+		t.Fatalf("expected 2, got %d", len(result))
+	}
+	if result[0].CLAId != "0" || result[0].URL != "https://example.com/a.pdf" || result[0].Language != "en" {
+		t.Errorf("unexpected result[0]: %+v", result[0])
+	}
+	if result[1].CLAId != "1" || result[1].Language != "zh" {
+		t.Errorf("unexpected result[1]: %+v", result[1])
+	}
+}
+
+func TestToCLADetailEmpty(t *testing.T) {
+	adapter := &claAdatper{}
+	result := adapter.toCLADetail([]app.CLADTO{})
+	if len(result) != 0 {
+		t.Errorf("expected empty, got %d", len(result))
+	}
+}

--- a/signing/adapter/corp_signing_test.go
+++ b/signing/adapter/corp_signing_test.go
@@ -1,0 +1,53 @@
+package adapter
+
+import (
+	"testing"
+)
+
+func TestIsValidaCorpEmailDomain(t *testing.T) {
+	adapter := &corpSigningAdatper{
+		invalidCorpEmailDomain: []string{"gmail.com", "yahoo.com"},
+	}
+
+	if !adapter.isValidaCorpEmailDomain("corp.com") {
+		t.Error("expected valid for non-blocklisted domain")
+	}
+	if adapter.isValidaCorpEmailDomain("gmail.com") {
+		t.Error("expected invalid for gmail.com")
+	}
+	if adapter.isValidaCorpEmailDomain("GMAIL.com") {
+		t.Error("expected invalid for GMAIL.com (case insensitive)")
+	}
+}
+
+func TestIsValidaCorpEmailDomainEmptyBlacklist(t *testing.T) {
+	adapter := &corpSigningAdatper{
+		invalidCorpEmailDomain: []string{},
+	}
+	if !adapter.isValidaCorpEmailDomain("gmail.com") {
+		t.Error("expected valid when blacklist is empty")
+	}
+}
+
+func TestNewCorpSigningAdapter(t *testing.T) {
+	adapter := NewCorpSigningAdapter(nil, []string{"GMAIL.COM", "YAHOO.COM"})
+	if len(adapter.invalidCorpEmailDomain) != 2 {
+		t.Fatalf("expected 2 domains, got %d", len(adapter.invalidCorpEmailDomain))
+	}
+	if adapter.invalidCorpEmailDomain[0] != "gmail.com" {
+		t.Errorf("expected lowercase 'gmail.com', got '%s'", adapter.invalidCorpEmailDomain[0])
+	}
+	if adapter.invalidCorpEmailDomain[1] != "yahoo.com" {
+		t.Errorf("expected lowercase 'yahoo.com', got '%s'", adapter.invalidCorpEmailDomain[1])
+	}
+}
+
+func TestNewCorpSigningAdapterEmptyDomains(t *testing.T) {
+	adapter := NewCorpSigningAdapter(nil, nil)
+	if adapter == nil {
+		t.Fatal("expected non-nil")
+	}
+	if len(adapter.invalidCorpEmailDomain) != 0 {
+		t.Errorf("expected 0 domains, got %d", len(adapter.invalidCorpEmailDomain))
+	}
+}

--- a/signing/adapter/employee_manager_test.go
+++ b/signing/adapter/employee_manager_test.go
@@ -1,0 +1,93 @@
+package adapter
+
+import (
+	"testing"
+
+	"github.com/opensourceways/app-cla-server/signing/app"
+)
+
+func TestToCorporationManagerCreateOption(t *testing.T) {
+	dto := &app.ManagerDTO{
+		Account:   "user001",
+		Role:      "admin",
+		Name:      "John",
+		EmailAddr: "john@test.com",
+		Password:  []byte("secret"),
+	}
+	result := toCorporationManagerCreateOption(dto)
+	if result.ID != "user001" {
+		t.Errorf("expected 'user001', got '%s'", result.ID)
+	}
+	if result.Role != "admin" {
+		t.Errorf("expected 'admin', got '%s'", result.Role)
+	}
+	if result.Name != "John" {
+		t.Errorf("expected 'John', got '%s'", result.Name)
+	}
+	if result.Email != "john@test.com" {
+		t.Errorf("expected 'john@test.com', got '%s'", result.Email)
+	}
+	if string(result.Password) != "secret" {
+		t.Errorf("expected 'secret', got '%s'", string(result.Password))
+	}
+}
+
+func TestToCorporationManagerListResult(t *testing.T) {
+	dto := &app.EmployeeManagerDTO{
+		ID:    "manager-1",
+		Name:  "Alice",
+		Email: "alice@test.com",
+	}
+	result := toCorporationManagerListResult(dto)
+	if result.ID != "manager-1" {
+		t.Errorf("expected 'manager-1', got '%s'", result.ID)
+	}
+	if result.Name != "Alice" {
+		t.Errorf("expected 'Alice', got '%s'", result.Name)
+	}
+	if result.Email != "alice@test.com" {
+		t.Errorf("expected 'alice@test.com', got '%s'", result.Email)
+	}
+}
+
+func TestNewEmployeeManagerAdapter(t *testing.T) {
+	adapter := NewEmployeeManagerAdapter(nil)
+	if adapter == nil {
+		t.Fatal("expected non-nil")
+	}
+}
+
+func TestNewEmployeeSigningAdapter(t *testing.T) {
+	adapter := NewEmployeeSigningAdapter(nil)
+	if adapter == nil {
+		t.Fatal("expected non-nil")
+	}
+}
+
+func TestNewCorpEmailDomainAdapter(t *testing.T) {
+	adapter := NewCorpEmailDomainAdapter(nil)
+	if adapter == nil {
+		t.Fatal("expected non-nil")
+	}
+}
+
+func TestNewCorpAdminAdapter(t *testing.T) {
+	adapter := NewCorpAdminAdapter(nil)
+	if adapter == nil {
+		t.Fatal("expected non-nil")
+	}
+}
+
+func TestNewCorpPDFAdapter(t *testing.T) {
+	adapter := NewCorpPDFAdapter(nil)
+	if adapter == nil {
+		t.Fatal("expected non-nil")
+	}
+}
+
+func TestNewIndividualSigningAdapter(t *testing.T) {
+	adapter := NewIndividualSigningAdapter(nil)
+	if adapter == nil {
+		t.Fatal("expected non-nil")
+	}
+}

--- a/signing/adapter/error_test.go
+++ b/signing/adapter/error_test.go
@@ -1,0 +1,93 @@
+package adapter
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/opensourceways/app-cla-server/models"
+	"github.com/opensourceways/app-cla-server/signing/domain"
+)
+
+func TestToModelError(t *testing.T) {
+	err := toModelError(domain.NewDomainError(domain.ErrorCodeUserFrozen))
+	if err == nil {
+		t.Fatal("expected non-nil")
+	}
+	if !err.IsErrorOf(models.ErrUserLoginFrozen) {
+		t.Errorf("expected ErrUserLoginFrozen, got '%s'", err.ErrCode())
+	}
+}
+
+func TestToModelErrorUnknownCode(t *testing.T) {
+	err := toModelError(errors.New("plain error"))
+	if err == nil {
+		t.Fatal("expected non-nil")
+	}
+	if !err.IsErrorOf(models.ErrSystemError) {
+		t.Errorf("expected ErrSystemError, got '%s'", err.ErrCode())
+	}
+}
+
+func TestToModelErrorDomainErrorWithMappedCode(t *testing.T) {
+	tests := []struct {
+		domainCode string
+		modelCode  string
+	}{
+		{domain.ErrorCodeCorpAdminExists, models.ErrNoLinkOrManagerExists},
+		{domain.ErrorCodeCorpSigningReSigning, models.ErrNoLinkOrResigned},
+		{domain.ErrorCodeCorpSigningNotFound, models.ErrUnsigned},
+		{domain.ErrorCodeCorpPDFNotFound, models.ErrUnuploaed},
+		{domain.ErrorCodeUserInvalidPassword, models.ErrInvalidPassword},
+		{domain.ErrorCodeUserNotExists, models.ErrUserNotExists},
+		{domain.ErrorCodeCLAExists, models.ErrCLAExists},
+		{domain.ErrorCodeCLACanNotRemove, models.ErrCLAIsUsed},
+		{domain.ErrorCodeLinkNotExists, models.ErrNoLink},
+		{domain.ErrorCodeLinkExists, models.ErrLinkExists},
+		{domain.ErrorCodeNoPermission, models.ErrNoPermission},
+		{domain.ErrorCodeCaptchaInvalid, models.ErrCaptchaInvalid},
+	}
+
+	for _, tt := range tests {
+		derr := domain.NewDomainError(tt.domainCode)
+		merr := toModelError(derr)
+		if !merr.IsErrorOf(tt.modelCode) {
+			t.Errorf("for %s: expected %s, got %s", tt.domainCode, tt.modelCode, merr.ErrCode())
+		}
+	}
+}
+
+func TestErrBadRequestParameter(t *testing.T) {
+	derr := domain.NewDomainError(domain.ErrorCodeUserInvalidAccount)
+	merr := errBadRequestParameter(derr)
+	if merr == nil {
+		t.Fatal("expected non-nil")
+	}
+	if !merr.IsErrorOf(models.ErrInvalidManagerID) {
+		t.Errorf("expected ErrInvalidManagerID, got '%s'", merr.ErrCode())
+	}
+}
+
+func TestErrBadRequestParameterPlainError(t *testing.T) {
+	merr := errBadRequestParameter(errors.New("plain"))
+	if !merr.IsErrorOf(models.ErrBadRequestParameter) {
+		t.Errorf("expected ErrBadRequestParameter, got '%s'", merr.ErrCode())
+	}
+}
+
+func TestCodeMap(t *testing.T) {
+	if v := codeMap(domain.ErrorCodeUserFrozen); v != models.ErrUserLoginFrozen {
+		t.Errorf("expected ErrUserLoginFrozen, got '%s'", v)
+	}
+	if v := codeMap("unknown_code"); v != models.ErrBadRequestParameter {
+		t.Errorf("expected ErrBadRequestParameter for unknown, got '%s'", v)
+	}
+}
+
+func TestAllErrorCodeMap(t *testing.T) {
+	// Ensure all mapped domain codes have valid model codes
+	for domainCode, modelCode := range errorCodeMap {
+		if domainCode == "" || modelCode == "" {
+			t.Errorf("empty key/value in errorCodeMap: %s -> %s", domainCode, modelCode)
+		}
+	}
+}

--- a/signing/adapter/individual_signing_test.go
+++ b/signing/adapter/individual_signing_test.go
@@ -1,0 +1,57 @@
+package adapter
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/opensourceways/app-cla-server/signing/app"
+	"github.com/opensourceways/app-cla-server/signing/domain/dp"
+)
+
+func init() {
+	dp.Init(&dp.Config{
+		MaxLengthOfEmail: 100,
+	})
+}
+
+func TestCreateCodeForSigning(t *testing.T) {
+	called := false
+	f := func(cmd *app.CmdToCreateVerificationCode) (string, error) {
+		called = true
+		if cmd.Id != "test-link" {
+			t.Errorf("expected 'test-link', got '%s'", cmd.Id)
+		}
+		if cmd.EmailAddr.EmailAddr() != "test@example.com" {
+			t.Errorf("expected email 'test@example.com', got '%s'", cmd.EmailAddr.EmailAddr())
+		}
+		return "123456", nil
+	}
+
+	code, err := createCodeForSigning("test-link", "test@example.com", f)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Error("expected f to be called")
+	}
+	if code != "123456" {
+		t.Errorf("expected '123456', got '%s'", code)
+	}
+}
+
+func TestCreateCodeForSigningInvalidEmail(t *testing.T) {
+	_, err := createCodeForSigning("link", "not-an-email", nil)
+	if err == nil {
+		t.Error("expected error for invalid email")
+	}
+}
+
+func TestCreateCodeForSigningWithError(t *testing.T) {
+	f := func(cmd *app.CmdToCreateVerificationCode) (string, error) {
+		return "", errors.New("service error")
+	}
+	_, err := createCodeForSigning("link", "test@example.com", f)
+	if err == nil {
+		t.Error("expected error")
+	}
+}

--- a/signing/adapter/link_test.go
+++ b/signing/adapter/link_test.go
@@ -1,0 +1,44 @@
+package adapter
+
+import (
+	"testing"
+
+	"github.com/opensourceways/app-cla-server/signing/domain"
+	"github.com/opensourceways/app-cla-server/signing/domain/dp"
+)
+
+func TestToFields(t *testing.T) {
+	adapter := &linkAdatper{}
+
+	fields := []domain.Field{
+		{Id: "0", Required: true, CLAField: dp.CLAField{Type: "text", Title: "Name", Desc: "Your Name", MaxLength: 50}},
+		{Id: "1", Required: false, CLAField: dp.CLAField{Type: "email", Title: "Email", Desc: "Your Email", MaxLength: 100}},
+	}
+
+	result := adapter.toFields(fields)
+	if len(result) != 2 {
+		t.Fatalf("expected 2, got %d", len(result))
+	}
+	if result[0].ID != "0" || result[0].Type != "text" || result[0].Title != "Name" {
+		t.Errorf("unexpected result[0]: %+v", result[0])
+	}
+	if !result[0].Required {
+		t.Error("expected Required=true for first field")
+	}
+	if result[1].Description != "Your Email" {
+		t.Errorf("expected 'Your Email', got '%s'", result[1].Description)
+	}
+}
+
+func TestToFieldsEmpty(t *testing.T) {
+	adapter := &linkAdatper{}
+	result := adapter.toFields([]domain.Field{})
+	if len(result) != 0 {
+		t.Errorf("expected empty, got %d", len(result))
+	}
+}
+
+func TestLinkAdapterFields(t *testing.T) {
+	_ = domain.Field{Id: "1", Required: true}
+	_ = dp.CLAField{Type: "text", Title: "Name", Desc: "desc", MaxLength: 50}
+}

--- a/signing/app/app_dto_more_test.go
+++ b/signing/app/app_dto_more_test.go
@@ -1,0 +1,180 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/opensourceways/app-cla-server/signing/domain"
+	"github.com/opensourceways/app-cla-server/signing/domain/dp"
+)
+
+func TestCmdToSignIndividualCLAToIndividualSigning(t *testing.T) {
+	e, _ := dp.NewEmailAddr("john@test.com")
+	n := dp.CreateName("John")
+	cmd := &CmdToSignIndividualCLA{
+		Link: domain.LinkInfo{
+			Id: "link-1",
+			CLAInfo: domain.CLAInfo{
+				CLAId:    "cla-1",
+				Language: dp.CreateLanguage("en"),
+			},
+		},
+		Rep: domain.Representative{
+			Name:      n,
+			EmailAddr: e,
+		},
+		AllSingingInfo:   domain.AllSingingInfo{"field1": "val1"},
+		VerificationCode: "123456",
+	}
+	signing := cmd.toIndividualSigning()
+	if signing.Link.Id != "link-1" || signing.Rep.Name.Name() != "John" {
+		t.Errorf("toIndividualSigning mismatch")
+	}
+}
+
+func TestCmdToSignIndividualCLAToCmd(t *testing.T) {
+	e, _ := dp.NewEmailAddr("john@test.com")
+	cmd := &CmdToSignIndividualCLA{
+		Link: domain.LinkInfo{Id: "link-1"},
+		Rep:  domain.Representative{EmailAddr: e},
+	}
+	vcCmd := cmd.toCmd()
+	if vcCmd.Id != "link-1" || vcCmd.EmailAddr.EmailAddr() != "john@test.com" {
+		t.Errorf("toCmd mismatch")
+	}
+}
+
+func TestCmdToSignCorpCLAToCorpSigning(t *testing.T) {
+	e, _ := dp.NewEmailAddr("ceo@corp.com")
+	n := dp.CreateName("CEO")
+	cn := dp.CreateCorpName("BigCorp")
+	cmd := &CmdToSignCorpCLA{
+		Link: domain.LinkInfo{
+			Id: "link-1",
+			CLAInfo: domain.CLAInfo{
+				CLAId:    "cla-1",
+				Language: dp.CreateLanguage("en"),
+			},
+		},
+		CorpName: cn,
+		Rep: domain.Representative{
+			Name:      n,
+			EmailAddr: e,
+		},
+		AllSingingInfo:   domain.AllSingingInfo{"f1": "v1"},
+		VerificationCode: "654321",
+	}
+	cs := cmd.toCorpSigning()
+	if cs.Corp.Name.CorpName() != "BigCorp" || cs.Rep.Name.Name() != "CEO" {
+		t.Errorf("toCorpSigning mismatch")
+	}
+	if cs.Date == "" {
+		t.Error("expected date to be set")
+	}
+}
+
+func TestCmdToSignCorpCLAToCmd(t *testing.T) {
+	e, _ := dp.NewEmailAddr("ceo@corp.com")
+	cmd := &CmdToSignCorpCLA{
+		Link: domain.LinkInfo{Id: "link-1"},
+		Rep:  domain.Representative{EmailAddr: e},
+	}
+	vcCmd := cmd.toCmd()
+	if vcCmd.Id != "link-1" || vcCmd.EmailAddr.EmailAddr() != "ceo@corp.com" {
+		t.Errorf("toCmd mismatch")
+	}
+}
+
+func TestCmdToFindCLAs(t *testing.T) {
+	cmd := &CmdToFindCLAs{
+		LinkId: "link-1",
+		Type:   dp.CLATypeCorp,
+	}
+	if cmd.LinkId != "link-1" || cmd.Type.CLAType() != "corporation" {
+		t.Errorf("CmdToFindCLAs mismatch")
+	}
+}
+
+func TestCorpSigningDTO(t *testing.T) {
+	dto := CorpSigningDTO{
+		Id:             "cs-1",
+		Date:           "2024-01-01",
+		Language:       "en",
+		CorpName:       "BigCorp",
+		RepName:        "CEO",
+		RepEmail:       "ceo@corp.com",
+		HasAdminAdded:  true,
+		HasPDFUploaded: false,
+	}
+	if dto.Id != "cs-1" {
+		t.Errorf("dto mismatch")
+	}
+}
+
+func TestCorpSigningInfoDTO(t *testing.T) {
+	dto := CorpSigningInfoDTO{
+		Date:     "2024-01-01",
+		CLAId:    "cla-1",
+		Language: "en",
+		CorpName: "BigCorp",
+		RepName:  "CEO",
+		RepEmail: "ceo@corp.com",
+		AllInfo:  domain.AllSingingInfo{"k": "v"},
+	}
+	if dto.CorpName != "BigCorp" {
+		t.Errorf("dto mismatch")
+	}
+}
+
+func TestCLADTO(t *testing.T) {
+	dto := CLADTO{
+		Id:       "cla-1",
+		Type:     "corporation",
+		URL:      "https://example.com/a.pdf",
+		Language: "en",
+	}
+	if dto.Id != "cla-1" || dto.Type != "corporation" {
+		t.Errorf("CLADTO mismatch")
+	}
+}
+
+func TestCLADetailDTO(t *testing.T) {
+	dto := CLADetailDTO{
+		Id:        "cla-1",
+		Fileds:    []domain.Field{},
+		Language:  "en",
+		LocalFile: "/tmp/cla.pdf",
+	}
+	if dto.Id != "cla-1" {
+		t.Errorf("CLADetailDTO mismatch")
+	}
+}
+
+func TestLinkCLADTO(t *testing.T) {
+	dto := LinkCLADTO{
+		CLA: CLADetailDTO{Id: "cla-1"},
+		Org: domain.OrgInfo{Alias: "Org"},
+		Email: domain.EmailInfo{
+			Addr:     dp.CreateEmailAddr("org@test.com"),
+			Platform: "gmail",
+		},
+	}
+	if dto.CLA.Id != "cla-1" || dto.Org.Alias != "Org" {
+		t.Errorf("LinkCLADTO mismatch")
+	}
+}
+
+func TestLinkDTO(t *testing.T) {
+	dto := LinkDTO{
+		Org:   domain.OrgInfo{Alias: "TestOrg"},
+		Email: domain.EmailInfo{Platform: "smtp"},
+	}
+	if dto.Org.Alias != "TestOrg" {
+		t.Errorf("LinkDTO mismatch")
+	}
+}
+
+func TestCmdToFindCLAsStruct(t *testing.T) {
+	_ = CmdToFindCLAs{LinkId: "L1", Type: dp.CLATypeIndividual}
+	_ = CmdToCheckSinging{LinkId: "L1", EmailAddr: dp.CreateEmailAddr("t@t.com")}
+	_ = CLAInfoDTO{CLAId: "c1", Language: "en"}
+}

--- a/signing/app/app_dto_test.go
+++ b/signing/app/app_dto_test.go
@@ -1,0 +1,106 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/opensourceways/app-cla-server/signing/domain"
+	"github.com/opensourceways/app-cla-server/signing/domain/dp"
+)
+
+func TestCLAInfoToCLA(t *testing.T) {
+	url, _ := dp.NewURL("https://example.com/cla.pdf")
+	cmd := &CLAInfo{
+		URL:      url,
+		Text:     []byte("text"),
+		Type:     dp.CLATypeCorp,
+		Fields:   []domain.Field{},
+		Language: dp.CreateLanguage("en"),
+	}
+	cla := cmd.toCLA()
+	if cla.URL.URL() != "https://example.com/cla.pdf" {
+		t.Errorf("URL mismatch")
+	}
+	if cla.Type.CLAType() != "corporation" {
+		t.Errorf("type mismatch")
+	}
+}
+
+func TestCmdToUpdateCLANewCLA(t *testing.T) {
+	url, _ := dp.NewURL("https://example.com/new.pdf")
+	cmd := &CmdToUpdateCLA{
+		URL:      url,
+		Text:     []byte("new text"),
+		Type:     dp.CLATypeIndividual,
+		Language: dp.CreateLanguage("en"),
+	}
+	cla := cmd.newCLA()
+	if cla.URL.URL() != "https://example.com/new.pdf" {
+		t.Errorf("URL mismatch")
+	}
+	if cla.Type.CLAType() != "individual" {
+		t.Errorf("type mismatch")
+	}
+}
+
+func TestCmdToAddLinkToLink(t *testing.T) {
+	url, _ := dp.NewURL("https://example.com/c.pdf")
+	email, _ := dp.NewEmailAddr("org@test.com")
+	cmd := &CmdToAddLink{
+		Org: domain.OrgInfo{
+			Alias:      "TestOrg",
+			Logo:       "logo.png",
+			ProjectURL: "https://example.com",
+		},
+		Email:     email,
+		Submitter: "admin",
+		CLAs: []CLAInfo{
+			{
+				URL:      url,
+				Text:     []byte("CLA content"),
+				Type:     dp.CLATypeCorp,
+				Language: dp.CreateLanguage("en"),
+			},
+		},
+	}
+	link := cmd.toLink()
+	if link.Org.Alias != "TestOrg" {
+		t.Errorf("expected 'TestOrg', got '%s'", link.Org.Alias)
+	}
+	if link.Submitter != "admin" {
+		t.Errorf("expected 'admin', got '%s'", link.Submitter)
+	}
+	if len(link.CLAs) != 1 {
+		t.Fatalf("expected 1 CLA, got %d", len(link.CLAs))
+	}
+	if link.CLAs[0].Id != "0" {
+		t.Errorf("expected Id '0', got '%s'", link.CLAs[0].Id)
+	}
+	if link.CLANum != 1 {
+		t.Errorf("expected CLANum=1, got %d", link.CLANum)
+	}
+}
+
+func TestCmdToAddLinkWithMultipleCLAs(t *testing.T) {
+	url1, _ := dp.NewURL("https://example.com/a.pdf")
+	url2, _ := dp.NewURL("https://example.com/b.pdf")
+	email, _ := dp.NewEmailAddr("org@test.com")
+	cmd := &CmdToAddLink{
+		Email:     email,
+		Submitter: "admin",
+		Org:       domain.OrgInfo{Alias: "X"},
+		CLAs: []CLAInfo{
+			{URL: url1, Text: []byte("a"), Type: dp.CLATypeCorp, Language: dp.CreateLanguage("en")},
+			{URL: url2, Text: []byte("b"), Type: dp.CLATypeIndividual, Language: dp.CreateLanguage("en")},
+		},
+	}
+	link := cmd.toLink()
+	if len(link.CLAs) != 2 {
+		t.Fatalf("expected 2 CLAs, got %d", len(link.CLAs))
+	}
+	if link.CLAs[0].Id != "0" || link.CLAs[1].Id != "1" {
+		t.Errorf("expected Ids 0 and 1, got %s and %s", link.CLAs[0].Id, link.CLAs[1].Id)
+	}
+	if link.CLANum != 2 {
+		t.Errorf("expected CLANum=2, got %d", link.CLANum)
+	}
+}

--- a/signing/app/check_community_manager_test.go
+++ b/signing/app/check_community_manager_test.go
@@ -1,0 +1,63 @@
+package app
+
+import (
+	"testing"
+
+	commonRepo "github.com/opensourceways/app-cla-server/common/domain/repository"
+	"github.com/opensourceways/app-cla-server/signing/domain"
+	"github.com/opensourceways/app-cla-server/signing/domain/repository"
+)
+
+type mockLinkRepo struct {
+	findRes domain.Link
+	findErr error
+}
+
+func (m *mockLinkRepo) Find(linkId string) (domain.Link, error) { return m.findRes, m.findErr }
+func (m *mockLinkRepo) FindAll(string) ([]repository.LinkSummary, error) { return nil, nil }
+func (m *mockLinkRepo) NewLinkId() string                               { return "" }
+func (m *mockLinkRepo) Add(*domain.Link) error                          { return nil }
+func (m *mockLinkRepo) Remove(*domain.Link) error                       { return nil }
+func (m *mockLinkRepo) AddCLA(*domain.Link, *domain.CLA) error          { return nil }
+func (m *mockLinkRepo) UpdateCLA(*domain.Link, *domain.CLA) error       { return nil }
+func (m *mockLinkRepo) RemoveCLA(*domain.Link, *domain.CLA) error       { return nil }
+func (m *mockLinkRepo) ListAll() ([]repository.LinkCLA, error)          { return nil, nil }
+
+func TestCheckIfCommunityManagerSuccess(t *testing.T) {
+	repo := &mockLinkRepo{
+		findRes: domain.Link{
+			Id:        "link-1",
+			Submitter: "admin",
+		},
+	}
+	link, err := checkIfCommunityManager("admin", "link-1", repo)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if link.Id != "link-1" {
+		t.Errorf("expected 'link-1', got '%s'", link.Id)
+	}
+}
+
+func TestCheckIfCommunityManagerNotFound(t *testing.T) {
+	repo := &mockLinkRepo{
+		findErr: commonRepo.NewErrorResourceNotFound(nil),
+	}
+	_, err := checkIfCommunityManager("admin", "link-1", repo)
+	if err == nil {
+		t.Error("expected error for not found")
+	}
+}
+
+func TestCheckIfCommunityManagerNoPermission(t *testing.T) {
+	repo := &mockLinkRepo{
+		findRes: domain.Link{
+			Id:        "link-1",
+			Submitter: "admin",
+		},
+	}
+	_, err := checkIfCommunityManager("other-user", "link-1", repo)
+	if err == nil {
+		t.Error("expected error for no permission")
+	}
+}

--- a/signing/app/user_dto_test.go
+++ b/signing/app/user_dto_test.go
@@ -1,0 +1,68 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/opensourceways/app-cla-server/signing/domain/dp"
+)
+
+func TestCmdToChangePasswordValidate(t *testing.T) {
+	old, _ := dp.NewPassword([]byte("old"))
+	newPw, _ := dp.NewPassword([]byte("new"))
+	cmd := &CmdToChangePassword{Id: "user-1", OldOne: old, NewOne: newPw}
+	if err := cmd.Validate(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestCmdToChangePasswordValidateSame(t *testing.T) {
+	same, _ := dp.NewPassword([]byte("same"))
+	cmd := &CmdToChangePassword{OldOne: same, NewOne: same}
+	if err := cmd.Validate(); err == nil {
+		t.Error("expected error for same password")
+	}
+}
+
+func TestCmdToLoginClear(t *testing.T) {
+	pw, _ := dp.NewPassword([]byte("secret"))
+	cmd := &CmdToLogin{Password: pw}
+	cmd.clear()
+	// After clear, password bytes should be zeroed
+	if string(pw.Password()) == "secret" {
+		t.Error("expected password to be cleared")
+	}
+}
+
+func TestCmdToChangePasswordClear(t *testing.T) {
+	old, _ := dp.NewPassword([]byte("old"))
+	newPw, _ := dp.NewPassword([]byte("new"))
+	cmd := &CmdToChangePassword{OldOne: old, NewOne: newPw}
+	cmd.clear()
+	if string(old.Password()) == "old" || string(newPw.Password()) == "new" {
+		t.Error("expected passwords to be cleared")
+	}
+}
+
+func TestCmdToResetPasswordClear(t *testing.T) {
+	newPw, _ := dp.NewPassword([]byte("new"))
+	cmd := &CmdToResetPassword{NewOne: newPw}
+	cmd.clear()
+	if string(newPw.Password()) == "new" {
+		t.Error("expected password to be cleared")
+	}
+}
+
+func TestCmdToGenKeyForPasswordRetrievalPurpose(t *testing.T) {
+	e, _ := dp.NewEmailAddr("user@test.com")
+	cmd := &CmdToGenKeyForPasswordRetrieval{
+		Id:        "link-1",
+		EmailAddr: e,
+	}
+	p, err := cmd.purpose()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if p == nil || p.Purpose() == "" {
+		t.Error("expected non-empty purpose")
+	}
+}

--- a/signing/app/verification_code_dto_test.go
+++ b/signing/app/verification_code_dto_test.go
@@ -1,0 +1,71 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/opensourceways/app-cla-server/signing/domain/dp"
+)
+
+func init() {
+	dp.Init(&dp.Config{MaxLengthOfEmail: 100})
+}
+
+func TestCmdToCreateVerificationCodeGenPurpose(t *testing.T) {
+	e, _ := dp.NewEmailAddr("test@example.com")
+	cmd := &CmdToCreateVerificationCode{
+		Id:        "link-1",
+		EmailAddr: e,
+	}
+	p, err := cmd.genPurpose("corp")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if p == nil || p.Purpose() == "" {
+		t.Error("expected non-empty purpose")
+	}
+}
+
+func TestCmdToCreateCodeForCorpSigningPurpose(t *testing.T) {
+	e, _ := dp.NewEmailAddr("corp@example.com")
+	cmd := &cmdToCreateCodeForCorpSigning{
+		Id:        "cs-1",
+		EmailAddr: e,
+	}
+	p, err := cmd.purpose()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if p == nil || p.Purpose() == "" {
+		t.Error("expected non-empty purpose")
+	}
+}
+
+func TestCmdToCreateCodeForEmployeeSigningPurpose(t *testing.T) {
+	e, _ := dp.NewEmailAddr("employee@example.com")
+	cmd := &cmdToCreateCodeForEmployeeSigning{
+		Id:        "emp-1",
+		EmailAddr: e,
+	}
+	p, err := cmd.purpose()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if p == nil || p.Purpose() == "" {
+		t.Error("expected non-empty purpose")
+	}
+}
+
+func TestCmdToCreateCodeForIndividualSigningPurpose(t *testing.T) {
+	e, _ := dp.NewEmailAddr("individual@example.com")
+	cmd := &cmdToCreateCodeForIndividualSigning{
+		Id:        "ind-1",
+		EmailAddr: e,
+	}
+	p, err := cmd.purpose()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if p == nil || p.Purpose() == "" {
+		t.Error("expected non-empty purpose")
+	}
+}

--- a/signing/app/verification_code_test.go
+++ b/signing/app/verification_code_test.go
@@ -1,0 +1,69 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	"github.com/opensourceways/app-cla-server/signing/domain"
+	"github.com/opensourceways/app-cla-server/signing/domain/dp"
+)
+
+type mockVCService struct {
+	newCode        string
+	newErr         error
+	newIfItCanCode string
+	newIfItCanErr  error
+	verifyErr      error
+}
+
+func (m *mockVCService) New(p dp.Purpose) (string, error)            { return m.newCode, m.newErr }
+func (m *mockVCService) NewIfItCan(p dp.Purpose, interval time.Duration) (string, error) {
+	return m.newIfItCanCode, m.newIfItCanErr
+}
+func (m *mockVCService) Verify(key *domain.VerificationCodeKey) error { return m.verifyErr }
+
+type mockVCPurpose struct {
+	p   dp.Purpose
+	err error
+}
+
+func (m *mockVCPurpose) purpose() (dp.Purpose, error) { return m.p, m.err }
+
+func TestVerificationCodeServiceNewCode(t *testing.T) {
+	vc := &verificationCodeService{
+		vc: &mockVCService{newCode: "123456"},
+	}
+	p, _ := dp.NewPurpose("test-purpose")
+	code, err := vc.newCode(&mockVCPurpose{p: p})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != "123456" {
+		t.Errorf("expected '123456', got '%s'", code)
+	}
+}
+
+func TestVerificationCodeServiceNewCodeIfItCan(t *testing.T) {
+	vc := &verificationCodeService{
+		vc: &mockVCService{newIfItCanCode: "654321"},
+	}
+	p, _ := dp.NewPurpose("test-purpose")
+	code, err := vc.newCodeIfItCan(&mockVCPurpose{p: p}, time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != "654321" {
+		t.Errorf("expected '654321', got '%s'", code)
+	}
+}
+
+func TestVerificationCodeServiceValidate(t *testing.T) {
+	vc := &verificationCodeService{
+		vc: &mockVCService{},
+	}
+	p, _ := dp.NewPurpose("validate-purpose")
+	err := vc.validate(&mockVCPurpose{p: p}, "code123")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/signing/domain/accesstokenservice/accesstokenservice_test.go
+++ b/signing/domain/accesstokenservice/accesstokenservice_test.go
@@ -1,0 +1,210 @@
+package accesstokenservice
+
+import (
+	"encoding/base64"
+	"testing"
+
+	commonRepo "github.com/opensourceways/app-cla-server/common/domain/repository"
+	"github.com/opensourceways/app-cla-server/signing/domain"
+	"github.com/opensourceways/app-cla-server/signing/domain/encryption"
+	"github.com/opensourceways/app-cla-server/signing/domain/randombytes"
+	"github.com/opensourceways/app-cla-server/signing/domain/repository"
+)
+
+type mockAccessTokenRepo struct {
+	addData  *domain.AccessToken
+	addIdx   string
+	addErr   error
+	findData domain.AccessToken
+	findErr  error
+	delErr   error
+}
+
+func (m *mockAccessTokenRepo) Add(v *domain.AccessToken) (string, error) {
+	m.addData = v
+	return m.addIdx, m.addErr
+}
+func (m *mockAccessTokenRepo) Find(key string) (domain.AccessToken, error) {
+	return m.findData, m.findErr
+}
+func (m *mockAccessTokenRepo) Delete(key string) error { return m.delErr }
+
+type mockEncryption struct {
+	encryptData []byte
+	encryptErr  error
+	isSameVal   bool
+}
+
+func (m *mockEncryption) Encrypt(v []byte) ([]byte, error) { return m.encryptData, m.encryptErr }
+func (m *mockEncryption) IsSame(plain, encrypted []byte) bool {
+	return m.isSameVal
+}
+
+type mockRandomBytes struct {
+	data []byte
+	err  error
+}
+
+func (m *mockRandomBytes) New(n int) ([]byte, error) { return m.data, m.err }
+
+func TestNewAccessTokenService(t *testing.T) {
+	s := NewAccessTokenService(&mockAccessTokenRepo{}, &mockEncryption{}, &mockRandomBytes{})
+	if s == nil {
+		t.Fatal("expected non-nil")
+	}
+}
+
+func TestAccessTokenServiceAdd(t *testing.T) {
+	randomData := make([]byte, csrfTokenLen)
+	for i := range randomData {
+		randomData[i] = byte(i)
+	}
+	encrypted := []byte("encrypted-csrf")
+
+	repo := &mockAccessTokenRepo{addIdx: "token-1"}
+	encrypt := &mockEncryption{encryptData: encrypted}
+	randBytes := &mockRandomBytes{data: randomData}
+
+	s := NewAccessTokenService(repo, encrypt, randBytes)
+
+	k, err := s.Add([]byte("payload-data"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if k.Id != "token-1" {
+		t.Errorf("expected 'token-1', got '%s'", k.Id)
+	}
+	expectedCSRF := base64.StdEncoding.EncodeToString(randomData)
+	if k.CSRF != expectedCSRF {
+		t.Errorf("expected '%s', got '%s'", expectedCSRF, k.CSRF)
+	}
+	if string(repo.addData.Payload) != "payload-data" {
+		t.Errorf("expected 'payload-data', got '%s'", string(repo.addData.Payload))
+	}
+}
+
+func TestAccessTokenServiceValidate(t *testing.T) {
+	randomData := make([]byte, csrfTokenLen)
+	for i := range randomData {
+		randomData[i] = byte(i)
+	}
+	csrf := base64.StdEncoding.EncodeToString(randomData)
+
+	repo := &mockAccessTokenRepo{
+		findData: domain.AccessToken{
+			Expiry:        9999999999,
+			Payload:       []byte("payload"),
+			EncryptedCSRF: []byte("encrypted"),
+		},
+	}
+	encrypt := &mockEncryption{isSameVal: true}
+	randBytes := &mockRandomBytes{data: randomData}
+	encrypt2 := &mockEncryption{isSameVal: true, encryptData: []byte("enc2")}
+	validToken := domain.AccessToken{
+		Expiry:        9999999999,
+		Payload:       []byte("payload"),
+		EncryptedCSRF: []byte("encrypted"),
+	}
+	repo2 := &mockAccessTokenRepo{
+		addIdx:   "new-token",
+		findData: validToken,
+	}
+
+	// Validate the original token
+	s := &accessTokenService{repo: repo, encrypt: encrypt, randomBytes: randBytes}
+	payload, err := s.validate(domain.AccessTokenKey{Id: "old", CSRF: csrf})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(payload) != "payload" {
+		t.Errorf("expected 'payload', got '%s'", string(payload))
+	}
+
+	// ValidateAndRefresh
+	s2 := &accessTokenService{repo: repo2, encrypt: encrypt2, randomBytes: randBytes}
+	newKey, p, err := s2.ValidateAndRefresh(domain.AccessTokenKey{Id: "old", CSRF: csrf})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if newKey.Id != "new-token" {
+		t.Errorf("expected 'new-token', got '%s'", newKey.Id)
+	}
+	_ = p
+}
+
+func TestAccessTokenServiceValidateInvalidCSRF(t *testing.T) {
+	s := &accessTokenService{
+		repo:    &mockAccessTokenRepo{},
+		encrypt: &mockEncryption{},
+	}
+	_, err := s.validate(domain.AccessTokenKey{CSRF: "invalid-base64!!!"})
+	if err == nil {
+		t.Error("expected error for invalid base64 CSRF")
+	}
+}
+
+func TestAccessTokenServiceValidateWrongLength(t *testing.T) {
+	short := base64.StdEncoding.EncodeToString([]byte("short"))
+	s := &accessTokenService{
+		repo:    &mockAccessTokenRepo{},
+		encrypt: &mockEncryption{},
+	}
+	_, err := s.validate(domain.AccessTokenKey{CSRF: short})
+	if err == nil {
+		t.Error("expected error for short CSRF")
+	}
+}
+
+func TestAccessTokenServiceValidateNotFound(t *testing.T) {
+	randomData := make([]byte, csrfTokenLen)
+	csrf := base64.StdEncoding.EncodeToString(randomData)
+	repo := &mockAccessTokenRepo{
+		findErr: commonRepo.NewErrorResourceNotFound(nil),
+	}
+	s := &accessTokenService{repo: repo, encrypt: &mockEncryption{}}
+	_, err := s.validate(domain.AccessTokenKey{CSRF: csrf})
+	if err == nil {
+		t.Error("expected error for not found")
+	}
+}
+
+func TestAccessTokenServiceValidateExpired(t *testing.T) {
+	randomData := make([]byte, csrfTokenLen)
+	csrf := base64.StdEncoding.EncodeToString(randomData)
+	repo := &mockAccessTokenRepo{
+		findData: domain.AccessToken{
+			Expiry:        1, // expired
+			Payload:       []byte("p"),
+			EncryptedCSRF: []byte("c"),
+		},
+	}
+	s := &accessTokenService{repo: repo, encrypt: &mockEncryption{}}
+	_, err := s.validate(domain.AccessTokenKey{CSRF: csrf})
+	if err == nil {
+		t.Error("expected error for expired token")
+	}
+}
+
+func TestAccessTokenServiceValidateWrongCSRF(t *testing.T) {
+	randomData := make([]byte, csrfTokenLen)
+	csrf := base64.StdEncoding.EncodeToString(randomData)
+	repo := &mockAccessTokenRepo{
+		findData: domain.AccessToken{
+			Expiry:        9999999999,
+			Payload:       []byte("p"),
+			EncryptedCSRF: []byte("real-encrypted"),
+		},
+	}
+	encrypt := &mockEncryption{isSameVal: false} // CSRF doesn't match
+	s := &accessTokenService{repo: repo, encrypt: encrypt}
+	_, err := s.validate(domain.AccessTokenKey{CSRF: csrf})
+	if err == nil {
+		t.Error("expected error for wrong CSRF")
+	}
+}
+
+// Verify interface compliance
+var _ AccessTokenService = (*accessTokenService)(nil)
+var _ repository.AccessToken = (*mockAccessTokenRepo)(nil)
+var _ encryption.Encryption = (*mockEncryption)(nil)
+var _ randombytes.RandomBytes = (*mockRandomBytes)(nil)

--- a/signing/domain/claservice/link_cache_test.go
+++ b/signing/domain/claservice/link_cache_test.go
@@ -1,0 +1,169 @@
+package claservice
+
+import (
+	"testing"
+
+	"github.com/opensourceways/app-cla-server/signing/domain"
+	"github.com/opensourceways/app-cla-server/signing/domain/dp"
+)
+
+func newTestCLA(id, claType string, langStr string) domain.CLA {
+	return domain.CLA{
+		Id:       id,
+		Type:     dp.CreateCLAType(claType),
+		Language: dp.CreateLanguage(langStr),
+	}
+}
+
+func TestLinkCacheContains(t *testing.T) {
+	lc := &linkCache{
+		cache: map[string][]domain.CLA{
+			"link1": {newTestCLA("cla1", "corporation", "en")},
+		},
+	}
+
+	if !lc.contains("link1", "cla1") {
+		t.Error("expected true for existing cla")
+	}
+	if lc.contains("link1", "nonexistent") {
+		t.Error("expected false for non-existent cla id")
+	}
+	if lc.contains("nonexistent", "cla1") {
+		t.Error("expected false for non-existent link id")
+	}
+}
+
+func TestLinkCacheGetClaId(t *testing.T) {
+	lc := &linkCache{
+		cache: map[string][]domain.CLA{
+			"link1": {
+				newTestCLA("id0", "corporation", "en"),
+				newTestCLA("id1", "individual", "en"),
+			},
+		},
+	}
+
+	id := lc.getClaId("link1", dp.CLATypeCorp, dp.CreateLanguage("en"))
+	if id != "id0" {
+		t.Errorf("expected 'id0', got '%s'", id)
+	}
+
+	id = lc.getClaId("link1", dp.CLATypeIndividual, dp.CreateLanguage("en"))
+	if id != "id1" {
+		t.Errorf("expected 'id1', got '%s'", id)
+	}
+
+	id = lc.getClaId("link1", dp.CreateCLAType("unknown"), dp.CreateLanguage("en"))
+	if id != "" {
+		t.Errorf("expected '', got '%s'", id)
+	}
+
+	id = lc.getClaId("nonexistent", dp.CLATypeCorp, dp.CreateLanguage("en"))
+	if id != "" {
+		t.Errorf("expected '', got '%s'", id)
+	}
+}
+
+func TestLinkCacheUpdateNewLink(t *testing.T) {
+	lc := &linkCache{
+		cache: make(map[string][]domain.CLA),
+	}
+
+	cla := newTestCLA("new", "corporation", "en")
+	lc.update("link1", &cla)
+
+	if !lc.contains("link1", "new") {
+		t.Error("expected cached CLA after update")
+	}
+}
+
+func TestLinkCacheUpdateExistingType(t *testing.T) {
+	lc := &linkCache{
+		cache: map[string][]domain.CLA{
+			"link1": {newTestCLA("old", "corporation", "en")},
+		},
+	}
+
+	updated := newTestCLA("new", "corporation", "en")
+	lc.update("link1", &updated)
+
+	if lc.contains("link1", "old") {
+		t.Error("expected old CLA to be replaced")
+	}
+	if !lc.contains("link1", "new") {
+		t.Error("expected new CLA to be cached")
+	}
+}
+
+func TestLinkCacheUpdateNewLanguage(t *testing.T) {
+	lc := &linkCache{
+		cache: map[string][]domain.CLA{
+			"link1": {newTestCLA("0", "corporation", "en")},
+		},
+	}
+
+	// Add different language
+	newCLA := newTestCLA("1", "corporation", "zh")
+	lc.update("link1", &newCLA)
+
+	if !lc.contains("link1", "0") {
+		t.Error("expected original CLA to remain")
+	}
+	if !lc.contains("link1", "1") {
+		t.Error("expected new CLA to be added")
+	}
+}
+
+func TestLinkCacheRemoveLink(t *testing.T) {
+	lc := &linkCache{
+		cache: map[string][]domain.CLA{
+			"link1": {newTestCLA("0", "corporation", "en")},
+			"link2": {newTestCLA("1", "individual", "en")},
+		},
+	}
+
+	lc.removeLink("link1")
+	if lc.contains("link1", "0") {
+		t.Error("expected link1 to be removed")
+	}
+	if !lc.contains("link2", "1") {
+		t.Error("expected link2 to remain")
+	}
+}
+
+func TestLinkCacheRemoveCLA(t *testing.T) {
+	lc := &linkCache{
+		cache: map[string][]domain.CLA{
+			"link1": {
+				newTestCLA("0", "corporation", "en"),
+				newTestCLA("1", "individual", "en"),
+			},
+		},
+	}
+
+	lc.removeCLA("link1", "0")
+	if lc.contains("link1", "0") {
+		t.Error("expected cla0 to be removed")
+	}
+	if !lc.contains("link1", "1") {
+		t.Error("expected cla1 to remain")
+	}
+
+	lc.removeCLA("link1", "1")
+	if lc.contains("link1", "1") {
+		t.Error("expected cla1 to be removed")
+	}
+	// link1 still exists with empty slice
+	if len(lc.cache["link1"]) != 0 {
+		t.Errorf("expected empty slice, got %d items", len(lc.cache["link1"]))
+	}
+}
+
+func TestLinkCacheRemoveCLANonexistentLink(t *testing.T) {
+	lc := &linkCache{
+		cache: make(map[string][]domain.CLA),
+	}
+
+	// should not panic
+	lc.removeCLA("nonexistent", "0")
+}

--- a/signing/domain/domain_test.go
+++ b/signing/domain/domain_test.go
@@ -1,0 +1,426 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/opensourceways/app-cla-server/signing/domain/dp"
+)
+
+func init() {
+	config = Config{
+		IsTestEnvironment:       false,
+		MaxNumOfFailedLogin:     5,
+		NeedCaptchaThreshold:    1,
+		AccessTokenExpiry:       3600,
+		CommunityManagerLinkId:  "community_link",
+		InvalidCorpEmailDomain:  "gmail.com,yahoo.com",
+	}
+}
+
+// --- Login ---
+
+func TestNewLogin(t *testing.T) {
+	l := NewLogin("test-id")
+	if l.Id != "test-id" {
+		t.Errorf("expected 'test-id', got '%s'", l.Id)
+	}
+	if l.Frozen {
+		t.Error("expected not frozen")
+	}
+	if l.FailedNum != 0 {
+		t.Errorf("expected 0, got %d", l.FailedNum)
+	}
+}
+
+func TestLoginFail(t *testing.T) {
+	l := NewLogin("test")
+
+	// Fail 4 times should not freeze
+	for i := 1; i < config.MaxNumOfFailedLogin; i++ {
+		if l.Fail() {
+			t.Errorf("expected false on fail %d/%d", i, config.MaxNumOfFailedLogin)
+		}
+		if l.FailedNum != i {
+			t.Errorf("expected FailedNum=%d, got %d", i, l.FailedNum)
+		}
+	}
+
+	// 5th failure should freeze
+	if !l.Fail() {
+		t.Error("expected true on final failure")
+	}
+	if l.FailedNum != config.MaxNumOfFailedLogin {
+		t.Errorf("expected FailedNum=%d, got %d", config.MaxNumOfFailedLogin, l.FailedNum)
+	}
+	if !l.Frozen {
+		t.Error("expected frozen after max failures")
+	}
+}
+
+func TestLoginRetryNum(t *testing.T) {
+	l := NewLogin("test")
+	if n := l.RetryNum(); n != config.MaxNumOfFailedLogin {
+		t.Errorf("expected %d, got %d", config.MaxNumOfFailedLogin, n)
+	}
+
+	l.Fail()
+	if n := l.RetryNum(); n != config.MaxNumOfFailedLogin-1 {
+		t.Errorf("expected %d, got %d", config.MaxNumOfFailedLogin-1, n)
+	}
+
+	l.Frozen = true
+	if n := l.RetryNum(); n != 0 {
+		t.Errorf("expected 0 when frozen, got %d", n)
+	}
+}
+
+func TestLoginHasFailure(t *testing.T) {
+	l := NewLogin("test")
+	if l.HasFailure() {
+		t.Error("expected false for new login")
+	}
+
+	l.Fail()
+	if !l.HasFailure() {
+		t.Error("expected true after failure")
+	}
+}
+
+func TestLoginNeedCaptcha(t *testing.T) {
+	l := NewLogin("test")
+
+	// Fresh login should not need captcha
+	if l.NeedCaptcha() {
+		t.Error("expected false for new login")
+	}
+
+	// After 1 failure (threshold=1), should need captcha
+	l.Fail()
+	if !l.NeedCaptcha() {
+		t.Error("expected true after reaching threshold")
+	}
+
+	// Frozen should not need captcha
+	l.Frozen = true
+	if l.NeedCaptcha() {
+		t.Error("expected false when frozen")
+	}
+}
+
+// --- CLA ---
+
+func TestCLAIsMe(t *testing.T) {
+	lang := dp.CreateLanguage("en")
+	cla1 := &CLA{Type: dp.CLATypeCorp, Language: lang}
+	cla2 := &CLA{Type: dp.CLATypeCorp, Language: lang}
+	cla3 := &CLA{Type: dp.CLATypeIndividual, Language: lang}
+
+	if !cla1.isMe(cla2) {
+		t.Error("expected same type and language")
+	}
+	if cla1.isMe(cla3) {
+		t.Error("expected different type")
+	}
+}
+
+// --- Link ---
+
+func TestLinkCanDo(t *testing.T) {
+	link := &Link{Submitter: "admin"}
+	if err := link.CanDo("admin"); err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+	if err := link.CanDo("other"); err == nil {
+		t.Error("expected error for different user")
+	}
+}
+
+func TestLinkAddCLA(t *testing.T) {
+	link := &Link{CLANum: 0}
+	cla := &CLA{Type: dp.CLATypeCorp, Language: dp.CreateLanguage("en")}
+
+	if err := link.AddCLA(cla); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if cla.Id != "0" {
+		t.Errorf("expected Id '0', got '%s'", cla.Id)
+	}
+	if link.CLANum != 1 {
+		t.Errorf("expected CLANum=1, got %d", link.CLANum)
+	}
+
+	// After AddCLA assigns an ID, simulate the CLA being stored in the link's list.
+	link.CLAs = append(link.CLAs, *cla)
+
+	// Adding same type+language CLA should fail
+	dup := &CLA{Type: dp.CLATypeCorp, Language: dp.CreateLanguage("en")}
+	if err := link.AddCLA(dup); err == nil {
+		t.Error("expected error for duplicate CLA")
+	}
+}
+
+func TestLinkUpdateCLA(t *testing.T) {
+	link := &Link{CLANum: 0}
+	cla := &CLA{Type: dp.CLATypeCorp, Language: dp.CreateLanguage("en")}
+	link.CLAs = append(link.CLAs, *cla)
+
+	newCLA := &CLA{Type: dp.CLATypeCorp, Language: dp.CreateLanguage("en")}
+	if err := link.UpdateCLA(newCLA); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if newCLA.Id != "0" {
+		t.Errorf("expected Id '0', got '%s'", newCLA.Id)
+	}
+
+	// Updating non-existent CLA type should fail
+	unknown := &CLA{Type: dp.CLATypeIndividual, Language: dp.CreateLanguage("en")}
+	if err := link.UpdateCLA(unknown); err == nil {
+		t.Error("expected error for non-existent CLA type")
+	}
+}
+
+func TestLinkFindCLA(t *testing.T) {
+	link := &Link{
+		CLAs: []CLA{
+			{Id: "0", Type: dp.CLATypeCorp, Language: dp.CreateLanguage("en")},
+			{Id: "1", Type: dp.CLATypeIndividual, Language: dp.CreateLanguage("en")},
+		},
+	}
+
+	if c := link.FindCLA("0"); c == nil || c.Id != "0" {
+		t.Error("expected to find CLA with Id '0'")
+	}
+	if c := link.FindCLA("2"); c != nil {
+		t.Error("expected nil for non-existent CLA")
+	}
+}
+
+func TestLinkGetCLA(t *testing.T) {
+	link := &Link{
+		CLAs: []CLA{
+			{Id: "0", Type: dp.CLATypeCorp, Language: dp.CreateLanguage("en")},
+			{Id: "1", Type: dp.CLATypeIndividual, Language: dp.CreateLanguage("en")},
+		},
+	}
+
+	c := link.GetCLA(dp.CLATypeCorp, dp.CreateLanguage("en"))
+	if c == nil || c.Id != "0" {
+		t.Error("expected CLA with Id '0'")
+	}
+
+	c = link.GetCLA(dp.CLATypeIndividual, dp.CreateLanguage("zh"))
+	if c != nil {
+		t.Error("expected nil for missing language")
+	}
+}
+
+// --- User / UserBasicInfo ---
+
+func TestUserIsCommunityManager(t *testing.T) {
+	u := &User{LinkId: "community_link"}
+	if !u.IsCommunityManager() {
+		t.Error("expected true for community manager")
+	}
+
+	u2 := &User{LinkId: "other_link"}
+	if u2.IsCommunityManager() {
+		t.Error("expected false for non-community manager")
+	}
+}
+
+func TestUserBasicInfoResetPassword(t *testing.T) {
+	var oldPw = []byte("old")
+	u := &UserBasicInfo{Password: oldPw}
+	u.ResetPassword([]byte("new"))
+	if string(u.Password) != "new" {
+		t.Errorf("expected 'new', got '%s'", string(u.Password))
+	}
+	if !u.PasswordChanged {
+		t.Error("expected PasswordChanged=true")
+	}
+}
+
+func TestUserBasicInfoChangePassword(t *testing.T) {
+	u := &UserBasicInfo{Password: []byte("old")}
+
+	isCorrect := func(ciphertext []byte) bool {
+		return string(ciphertext) == "old"
+	}
+	genNew := func() ([]byte, error) {
+		return []byte("new"), nil
+	}
+
+	if err := u.ChangePassword(isCorrect, genNew); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if string(u.Password) != "new" {
+		t.Errorf("expected 'new', got '%s'", string(u.Password))
+	}
+}
+
+func TestUserBasicInfoChangePasswordWrongOld(t *testing.T) {
+	u := &UserBasicInfo{Password: []byte("old")}
+
+	isCorrect := func(ciphertext []byte) bool {
+		return false
+	}
+	genNew := func() ([]byte, error) {
+		return []byte("new"), nil
+	}
+
+	if err := u.ChangePassword(isCorrect, genNew); err == nil {
+		t.Error("expected error for wrong old password")
+	}
+}
+
+func TestUserBasicInfoUpdatePrivacyConsent(t *testing.T) {
+	u := &UserBasicInfo{}
+
+	if !u.UpdatePrivacyConsent("v1") {
+		t.Error("expected true for first consent")
+	}
+	if u.PrivacyConsent.Version != "v1" {
+		t.Errorf("expected 'v1', got '%s'", u.PrivacyConsent.Version)
+	}
+
+	if u.UpdatePrivacyConsent("v1") {
+		t.Error("expected false for same version")
+	}
+
+	if !u.UpdatePrivacyConsent("v2") {
+		t.Error("expected true for new version")
+	}
+	if u.PrivacyConsent.Version != "v2" {
+		t.Errorf("expected 'v2', got '%s'", u.PrivacyConsent.Version)
+	}
+}
+
+// --- AccessToken ---
+
+func TestNewAccessToken(t *testing.T) {
+	token := NewAccessToken([]byte("payload"), []byte("csrf"))
+	if string(token.Payload) != "payload" {
+		t.Errorf("expected 'payload', got '%s'", string(token.Payload))
+	}
+	if string(token.EncryptedCSRF) != "csrf" {
+		t.Errorf("expected 'csrf', got '%s'", string(token.EncryptedCSRF))
+	}
+}
+
+func TestAccessTokenIsValid(t *testing.T) {
+	token := NewAccessToken([]byte("payload"), []byte("csrf"))
+	if !token.IsValid() {
+		t.Error("expected valid token")
+	}
+}
+
+func TestAccessTokenIsExpired(t *testing.T) {
+	token := &AccessToken{
+		Expiry:        100, // very old timestamp
+		Payload:       []byte("p"),
+		EncryptedCSRF: []byte("c"),
+	}
+	if token.IsValid() {
+		t.Error("expected expired token to be invalid")
+	}
+}
+
+// --- Config ---
+
+func TestConfigSetDefault(t *testing.T) {
+	cfg := &Config{}
+	cfg.SetDefault()
+
+	if cfg.VerificationCodeExpiry != 300 {
+		t.Errorf("expected 300, got %d", cfg.VerificationCodeExpiry)
+	}
+	if cfg.AccessTokenExpiry != 3600 {
+		t.Errorf("expected 3600, got %d", cfg.AccessTokenExpiry)
+	}
+	if cfg.IntervalOfCreatingVC != 60 {
+		t.Errorf("expected 60, got %d", cfg.IntervalOfCreatingVC)
+	}
+	if cfg.MaxNumOfEmployeeManager != 5 {
+		t.Errorf("expected 5, got %d", cfg.MaxNumOfEmployeeManager)
+	}
+	if cfg.MaxSizeOfCLAContent <= 0 {
+		t.Error("expected positive default for max size")
+	}
+	if cfg.MaxNumOfFailedLogin != 5 {
+		t.Errorf("expected 5, got %d", cfg.MaxNumOfFailedLogin)
+	}
+	if cfg.NeedCaptchaThreshold != 1 {
+		t.Errorf("expected 1, got %d", cfg.NeedCaptchaThreshold)
+	}
+	if len(cfg.SourceOfCLAPDF) == 0 {
+		t.Error("expected default sources")
+	}
+	if cfg.FileTypeOfCLAContent != "pdf" {
+		t.Errorf("expected 'pdf', got '%s'", cfg.FileTypeOfCLAContent)
+	}
+	if cfg.CommunityManagerLinkId != "fake_link" {
+		t.Errorf("expected 'fake_link', got '%s'", cfg.CommunityManagerLinkId)
+	}
+	if cfg.GetIntervalOfCreatingVC() <= 0 {
+		t.Error("expected positive interval")
+	}
+}
+
+func TestConfigSetDefaultKeepsCustomValues(t *testing.T) {
+	cfg := &Config{
+		VerificationCodeExpiry:  600,
+		AccessTokenExpiry:       7200,
+		MaxNumOfEmployeeManager: 10,
+		MaxNumOfFailedLogin:     3,
+		NeedCaptchaThreshold:    2,
+		FileTypeOfCLAContent:    "docx",
+	}
+	cfg.SetDefault()
+
+	if cfg.VerificationCodeExpiry != 600 {
+		t.Errorf("expected 600, got %d", cfg.VerificationCodeExpiry)
+	}
+	if cfg.AccessTokenExpiry != 7200 {
+		t.Errorf("expected 7200, got %d", cfg.AccessTokenExpiry)
+	}
+	if cfg.MaxNumOfEmployeeManager != 10 {
+		t.Errorf("expected 10, got %d", cfg.MaxNumOfEmployeeManager)
+	}
+}
+
+func TestConfigInvalidCorpEmailDomains(t *testing.T) {
+	cfg := &Config{InvalidCorpEmailDomain: "gmail.com,yahoo.com"}
+	domains := cfg.InvalidCorpEmailDomains()
+	if len(domains) != 2 {
+		t.Fatalf("expected 2, got %d", len(domains))
+	}
+	if domains[0] != "gmail.com" {
+		t.Errorf("expected 'gmail.com', got '%s'", domains[0])
+	}
+	if domains[1] != "yahoo.com" {
+		t.Errorf("expected 'yahoo.com', got '%s'", domains[1])
+	}
+}
+
+func TestConfigInvalidCorpEmailDomainsEmpty(t *testing.T) {
+	cfg := &Config{}
+	domains := cfg.InvalidCorpEmailDomains()
+	if len(domains) != 1 || domains[0] != "" {
+		t.Errorf("expected single empty string, got %v", domains)
+	}
+}
+
+func TestConfigTestEnvironment(t *testing.T) {
+	cfg := &Config{IsTestEnvironment: true}
+	cfg.setTestDefaults()
+	if cfg.TestCaptchaAnswer != "123456" {
+		t.Errorf("expected '123456', got '%s'", cfg.TestCaptchaAnswer)
+	}
+
+	// Custom test answer should be preserved
+	cfg2 := &Config{IsTestEnvironment: true, TestCaptchaAnswer: "999999"}
+	cfg2.setTestDefaults()
+	if cfg2.TestCaptchaAnswer != "999999" {
+		t.Errorf("expected '999999', got '%s'", cfg2.TestCaptchaAnswer)
+	}
+}

--- a/signing/domain/dp/dp_test.go
+++ b/signing/domain/dp/dp_test.go
@@ -1,0 +1,520 @@
+package dp
+
+import (
+	"testing"
+)
+
+func init() {
+	config = Config{
+		MaxLengthOfName:     100,
+		MaxLengthOfTitle:    200,
+		MaxLengthOfEmail:    100,
+		MaxLengthOfAccount:  50,
+		MaxLengthOfCorpName: 100,
+		CLA: []claConfig{
+			{
+				Type: "corporation",
+				Fileds: []claFields{
+					{
+						Language: "en",
+						Fileds:   []CLAField{{Type: "text", Desc: "Name", Title: "Name", MaxLength: 50}},
+					},
+				},
+			},
+			{
+				Type: "individual",
+				Fileds: []claFields{
+					{
+						Language: "en",
+						Fileds:   []CLAField{{Type: "text", Desc: "Email", Title: "Email", MaxLength: 50}},
+					},
+				},
+			},
+		},
+	}
+	config.Validate()
+}
+
+// --- Purpose ---
+
+func TestNewPurpose(t *testing.T) {
+	p, err := NewPurpose("test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.Purpose() != "test" {
+		t.Errorf("expected 'test', got '%s'", p.Purpose())
+	}
+}
+
+func TestNewPurposeEmpty(t *testing.T) {
+	_, err := NewPurpose("")
+	if err == nil {
+		t.Error("expected error for empty purpose")
+	}
+}
+
+func TestCreatePurpose(t *testing.T) {
+	p := CreatePurpose("any")
+	if p.Purpose() != "any" {
+		t.Errorf("expected 'any', got '%s'", p.Purpose())
+	}
+}
+
+// --- URL ---
+
+func TestNewURL(t *testing.T) {
+	u, err := NewURL("https://example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if u.URL() != "https://example.com" {
+		t.Errorf("expected 'https://example.com', got '%s'", u.URL())
+	}
+}
+
+func TestNewURLEmpty(t *testing.T) {
+	_, err := NewURL("")
+	if err == nil {
+		t.Error("expected error for empty url")
+	}
+}
+
+func TestNewURLInvalid(t *testing.T) {
+	_, err := NewURL("not a url")
+	if err == nil {
+		t.Error("expected error for invalid url")
+	}
+}
+
+func TestCreateURL(t *testing.T) {
+	u := CreateURL("any")
+	if u.URL() != "any" {
+		t.Errorf("expected 'any', got '%s'", u.URL())
+	}
+}
+
+// --- CLAType ---
+
+func TestNewCLATypeCorp(t *testing.T) {
+	ct, err := NewCLAType("corporation")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ct.CLAType() != "corporation" {
+		t.Errorf("expected 'corporation', got '%s'", ct.CLAType())
+	}
+}
+
+func TestNewCLATypeIndividual(t *testing.T) {
+	ct, err := NewCLAType("individual")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ct.CLAType() != "individual" {
+		t.Errorf("expected 'individual', got '%s'", ct.CLAType())
+	}
+}
+
+func TestNewCLATypeInvalid(t *testing.T) {
+	_, err := NewCLAType("unknown")
+	if err == nil {
+		t.Error("expected error for invalid cla type")
+	}
+}
+
+func TestCreateCLAType(t *testing.T) {
+	ct := CreateCLAType("any")
+	if ct.CLAType() != "any" {
+		t.Errorf("expected 'any', got '%s'", ct.CLAType())
+	}
+}
+
+func TestIsCLATypeIndividual(t *testing.T) {
+	if !IsCLATypeIndividual(CLATypeIndividual) {
+		t.Error("expected true for individual type")
+	}
+	if IsCLATypeIndividual(CLATypeCorp) {
+		t.Error("expected false for corp type")
+	}
+	if IsCLATypeIndividual(nil) {
+		t.Error("expected false for nil")
+	}
+}
+
+// --- Name ---
+
+func TestNewName(t *testing.T) {
+	n, err := NewName("John")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n.Name() != "John" {
+		t.Errorf("expected 'John', got '%s'", n.Name())
+	}
+}
+
+func TestNewNameEmpty(t *testing.T) {
+	_, err := NewName("")
+	if err == nil {
+		t.Error("expected error for empty name")
+	}
+}
+
+func TestNewNameXSS(t *testing.T) {
+	_, err := NewName("<script>")
+	if err == nil {
+		t.Error("expected error for XSS content")
+	}
+}
+
+func TestNewNameTooLong(t *testing.T) {
+	s := make([]byte, config.MaxLengthOfName+1)
+	for i := range s {
+		s[i] = 'a'
+	}
+	_, err := NewName(string(s))
+	if err == nil {
+		t.Error("expected error for long name")
+	}
+}
+
+func TestCreateName(t *testing.T) {
+	n := CreateName("any")
+	if n.Name() != "any" {
+		t.Errorf("expected 'any', got '%s'", n.Name())
+	}
+}
+
+// --- Title ---
+
+func TestNewTitle(t *testing.T) {
+	title, err := NewTitle("Engineer")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if title.Title() != "Engineer" {
+		t.Errorf("expected 'Engineer', got '%s'", title.Title())
+	}
+}
+
+func TestNewTitleEmpty(t *testing.T) {
+	_, err := NewTitle("")
+	if err == nil {
+		t.Error("expected error for empty title")
+	}
+}
+
+func TestNewTitleTooLong(t *testing.T) {
+	s := make([]byte, config.MaxLengthOfTitle+1)
+	for i := range s {
+		s[i] = 'a'
+	}
+	_, err := NewTitle(string(s))
+	if err == nil {
+		t.Error("expected error for long title")
+	}
+}
+
+// --- EmailAddr ---
+
+func TestNewEmailAddr(t *testing.T) {
+	e, err := NewEmailAddr("test@example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if e.EmailAddr() != "test@example.com" {
+		t.Errorf("expected 'test@example.com', got '%s'", e.EmailAddr())
+	}
+	if e.Domain() != "example.com" {
+		t.Errorf("expected 'example.com', got '%s'", e.Domain())
+	}
+}
+
+func TestNewEmailAddrInvalid(t *testing.T) {
+	_, err := NewEmailAddr("not-an-email")
+	if err == nil {
+		t.Error("expected error for invalid email")
+	}
+}
+
+func TestNewEmailAddrEmpty(t *testing.T) {
+	_, err := NewEmailAddr("")
+	if err == nil {
+		t.Error("expected error for empty email")
+	}
+}
+
+func TestCreateEmailAddr(t *testing.T) {
+	e := CreateEmailAddr("any@test.com")
+	if e.EmailAddr() != "any@test.com" {
+		t.Errorf("expected 'any@test.com', got '%s'", e.EmailAddr())
+	}
+}
+
+// --- Account ---
+
+func TestNewAccountCommunity(t *testing.T) {
+	a, err := NewAccount("valid-user")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if a.Account() != "valid-user" {
+		t.Errorf("expected 'valid-user', got '%s'", a.Account())
+	}
+}
+
+func TestNewAccountCorpManager(t *testing.T) {
+	a, err := NewAccount("valid_user-org.enterprise.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if a.Account() != "valid_user-org.enterprise.com" {
+		t.Errorf("unexpected account value")
+	}
+}
+
+func TestNewAccountInvalid(t *testing.T) {
+	_, err := NewAccount("invalid account with spaces")
+	if err == nil {
+		t.Error("expected error for invalid account")
+	}
+}
+
+func TestNewAccountEmpty(t *testing.T) {
+	_, err := NewAccount("")
+	if err == nil {
+		t.Error("expected error for empty account")
+	}
+}
+
+func TestNewAccountTooLong(t *testing.T) {
+	s := make([]byte, config.MaxLengthOfAccount+1)
+	for i := range s {
+		s[i] = 'a'
+	}
+	_, err := NewAccount(string(s))
+	if err == nil {
+		t.Error("expected error for long account")
+	}
+}
+
+func TestCreateAccount(t *testing.T) {
+	a := CreateAccount("any")
+	if a.Account() != "any" {
+		t.Errorf("expected 'any', got '%s'", a.Account())
+	}
+}
+
+// --- CorpName ---
+
+func TestNewCorpName(t *testing.T) {
+	n, err := NewCorpName("Acme Corp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n.CorpName() != "Acme Corp" {
+		t.Errorf("expected 'Acme Corp', got '%s'", n.CorpName())
+	}
+}
+
+func TestNewCorpNameEmpty(t *testing.T) {
+	_, err := NewCorpName("")
+	if err == nil {
+		t.Error("expected error for empty corp name")
+	}
+}
+
+func TestNewCorpNameXSS(t *testing.T) {
+	_, err := NewCorpName("<script>alert(1)</script>")
+	if err == nil {
+		t.Error("expected error for XSS in corp name")
+	}
+}
+
+func TestNewCorpNameTooLong(t *testing.T) {
+	s := make([]byte, config.MaxLengthOfCorpName+1)
+	for i := range s {
+		s[i] = 'a'
+	}
+	_, err := NewCorpName(string(s))
+	if err == nil {
+		t.Error("expected error for long corp name")
+	}
+}
+
+func TestCreateCorpName(t *testing.T) {
+	n := CreateCorpName("any")
+	if n.CorpName() != "any" {
+		t.Errorf("expected 'any', got '%s'", n.CorpName())
+	}
+}
+
+// --- Password ---
+
+func TestNewPassword(t *testing.T) {
+	p, err := NewPassword([]byte("secret"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(p.Password()) != "secret" {
+		t.Errorf("expected 'secret', got '%s'", string(p.Password()))
+	}
+}
+
+func TestNewPasswordEmpty(t *testing.T) {
+	_, err := NewPassword([]byte{})
+	if err == nil {
+		t.Error("expected error for empty password")
+	}
+}
+
+func TestPasswordClear(t *testing.T) {
+	p, _ := NewPassword([]byte("secret"))
+	p.Clear()
+	b := p.Password()
+	for _, v := range b {
+		if v != 0 {
+			t.Error("expected all bytes to be zero after clear")
+		}
+	}
+}
+
+func TestIsSamePassword(t *testing.T) {
+	p1, _ := NewPassword([]byte("secret"))
+	p2, _ := NewPassword([]byte("secret"))
+	p3, _ := NewPassword([]byte("other"))
+	p4, _ := NewPassword([]byte("secret!"))
+
+	if !IsSamePassword(p1, p2) {
+		t.Error("expected same password")
+	}
+	if IsSamePassword(p1, p3) {
+		t.Error("expected different password")
+	}
+	if IsSamePassword(p1, p4) {
+		t.Error("expected different password (different length)")
+	}
+}
+
+// --- Language ---
+
+func TestNewLanguage(t *testing.T) {
+	l, err := NewLanguage("en")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if l.Language() != "en" {
+		t.Errorf("expected 'en', got '%s'", l.Language())
+	}
+}
+
+func TestNewLanguageInvalid(t *testing.T) {
+	_, err := NewLanguage("fr")
+	if err == nil {
+		t.Error("expected error for unsupported language")
+	}
+}
+
+func TestCreateLanguage(t *testing.T) {
+	l := CreateLanguage("any")
+	if l.Language() != "any" {
+		t.Errorf("expected 'any', got '%s'", l.Language())
+	}
+}
+
+// --- Config ---
+
+func TestConfigValidate(t *testing.T) {
+	cfg := &Config{
+		MaxLengthOfName:  50,
+		MaxLengthOfEmail: 50,
+		CLA: []claConfig{
+			{Type: "corporation", Fileds: []claFields{{Language: "en"}}},
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestConfigValidateInvalidCLAType(t *testing.T) {
+	cfg := &Config{
+		CLA: []claConfig{
+			{Type: "invalid_type"},
+		},
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error for invalid CLA type")
+	}
+}
+
+func TestConfigGetLanguage(t *testing.T) {
+	cfg := &Config{
+		CLA: []claConfig{
+			{Type: "corporation", Fileds: []claFields{
+				{Language: "en"},
+				{Language: "zh"},
+			}},
+		},
+	}
+	cfg.Validate()
+
+	if v := cfg.getLanguage("en"); v != "en" {
+		t.Errorf("expected 'en', got '%s'", v)
+	}
+	if v := cfg.getLanguage("ZH"); v != "zh" {
+		t.Errorf("expected 'zh', got '%s'", v)
+	}
+	if v := cfg.getLanguage("fr"); v != "" {
+		t.Errorf("expected '', got '%s'", v)
+	}
+}
+
+func TestGetCLAFileds(t *testing.T) {
+	cfg := &Config{
+		CLA: []claConfig{
+			{
+				Type: "corporation",
+				Fileds: []claFields{
+					{
+						Language: "en",
+						Fileds:   []CLAField{{Type: "text", Desc: "Name", Title: "Name", MaxLength: 50}},
+					},
+				},
+			},
+		},
+	}
+	cfg.Validate()
+	Init(cfg)
+
+	fields := GetCLAFileds(CLATypeCorp, CreateLanguage("en"))
+	if len(fields) != 1 {
+		t.Fatalf("expected 1 field, got %d", len(fields))
+	}
+	if fields[0].Title != "Name" {
+		t.Errorf("expected 'Name', got '%s'", fields[0].Title)
+	}
+}
+
+func TestGetCLAFiledsNotFound(t *testing.T) {
+	fields := GetCLAFileds(CLATypeIndividual, CreateLanguage("zh"))
+	if len(fields) != 0 {
+		t.Errorf("expected 0 fields, got %d", len(fields))
+	}
+}
+
+// --- CLAField ---
+
+func TestCLAFieldIsValidValue(t *testing.T) {
+	f := &CLAField{MaxLength: 10}
+	if !f.IsValidValue("short") {
+		t.Error("expected valid")
+	}
+	if f.IsValidValue("this is too long") {
+		t.Error("expected invalid for too long value")
+	}
+	if f.IsValidValue("<script>") {
+		t.Error("expected invalid for XSS content")
+	}
+}

--- a/signing/domain/emailcredential/emailcredential_test.go
+++ b/signing/domain/emailcredential/emailcredential_test.go
@@ -1,0 +1,98 @@
+package emailcredential
+
+import (
+	"testing"
+
+	commonRepo "github.com/opensourceways/app-cla-server/common/domain/repository"
+	"github.com/opensourceways/app-cla-server/signing/domain"
+	"github.com/opensourceways/app-cla-server/signing/domain/dp"
+	"github.com/opensourceways/app-cla-server/signing/domain/repository"
+	"github.com/opensourceways/app-cla-server/signing/domain/symmetricencryption"
+)
+
+type mockEmailCredentialRepo struct {
+	addData *domain.EmailCredential
+	addErr  error
+	findRes domain.EmailCredential
+	findErr error
+}
+
+func (m *mockEmailCredentialRepo) Add(e *domain.EmailCredential) error { m.addData = e; return m.addErr }
+func (m *mockEmailCredentialRepo) Find(ed dp.EmailAddr) (domain.EmailCredential, error) {
+	return m.findRes, m.findErr
+}
+
+type mockSymEncrypt2 struct {
+	encryptRes []byte
+	encryptErr error
+	decryptRes []byte
+	decryptErr error
+}
+
+func (m *mockSymEncrypt2) Encrypt(plain []byte) ([]byte, error) { return m.encryptRes, m.encryptErr }
+func (m *mockSymEncrypt2) Decrypt(cipher []byte) ([]byte, error) { return m.decryptRes, m.decryptErr }
+
+func TestNewEmailCredential(t *testing.T) {
+	s := NewEmailCredential(&mockEmailCredentialRepo{}, &mockSymEncrypt2{})
+	if s == nil {
+		t.Fatal("expected non-nil")
+	}
+}
+
+func TestEmailCredentialAdd(t *testing.T) {
+	encrypt := &mockSymEncrypt2{encryptRes: []byte("encrypted-token")}
+	repo := &mockEmailCredentialRepo{}
+	s := NewEmailCredential(repo, encrypt)
+
+	e := &domain.EmailCredential{
+		Addr:     dp.CreateEmailAddr("test@example.com"),
+		Token:    []byte("raw-token"),
+		Platform: "gmail",
+	}
+	if err := s.Add(e); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(repo.addData.Token) != "encrypted-token" {
+		t.Errorf("expected 'encrypted-token', got '%s'", string(repo.addData.Token))
+	}
+}
+
+func TestEmailCredentialFind(t *testing.T) {
+	encryptedToken := []byte("encrypted-token")
+	decryptedToken := []byte("decrypted-token")
+
+	repo := &mockEmailCredentialRepo{
+		findRes: domain.EmailCredential{
+			Addr:     dp.CreateEmailAddr("test@example.com"),
+			Token:    encryptedToken,
+			Platform: "gmail",
+		},
+	}
+	encrypt := &mockSymEncrypt2{decryptRes: decryptedToken}
+	s := NewEmailCredential(repo, encrypt)
+
+	e, err := s.Find(dp.CreateEmailAddr("test@example.com"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(e.Token) != "decrypted-token" {
+		t.Errorf("expected 'decrypted-token', got '%s'", string(e.Token))
+	}
+}
+
+func TestEmailCredentialFindNotFound(t *testing.T) {
+	repo := &mockEmailCredentialRepo{
+		findErr: commonRepo.NewErrorResourceNotFound(nil),
+	}
+	s := NewEmailCredential(repo, &mockSymEncrypt2{})
+
+	_, err := s.Find(dp.CreateEmailAddr("missing@test.com"))
+	if err == nil {
+		t.Error("expected error for not found")
+	}
+}
+
+// Verify interface compliance
+var _ EmailCredential = (*emailCredential)(nil)
+var _ repository.EmailCredential = (*mockEmailCredentialRepo)(nil)
+var _ symmetricencryption.Encryption = (*mockSymEncrypt2)(nil)

--- a/signing/domain/emailservice/emailservice_test.go
+++ b/signing/domain/emailservice/emailservice_test.go
@@ -1,0 +1,113 @@
+package emailservice
+
+import (
+	"errors"
+	"testing"
+)
+
+type mockEmailClient struct {
+	err   error
+	calls []*EmailMessage
+}
+
+func (m *mockEmailClient) SendEmail(msg *EmailMessage) error {
+	m.calls = append(m.calls, msg)
+	return m.err
+}
+
+func TestEmailMessageClearContent(t *testing.T) {
+	msg := &EmailMessage{}
+	msg.Content.WriteString("sensitive data")
+	msg.ClearContent()
+	if msg.Content.Len() != 0 {
+		t.Error("expected empty content after clear")
+	}
+}
+
+func TestClearContentZerosBytes(t *testing.T) {
+	msg := &EmailMessage{}
+	msg.Content.WriteString("hello")
+	// The underlying bytes should be zeroed
+	msg.ClearContent()
+	msg.Content.WriteString(" new")
+	s := msg.Content.String()
+	if s != " new" {
+		t.Errorf("expected ' new', got '%s'", s)
+	}
+}
+
+func TestRegisterAndSendEmail(t *testing.T) {
+	// Reset impl for test isolation
+	oldImpl := impl
+	impl = &emailServiceImpl{
+		clients: make(map[string]iEmail),
+	}
+	defer func() { impl = oldImpl }()
+
+	mock := &mockEmailClient{}
+	Register("test-platform", mock)
+
+	err := SendEmail("test-platform", &EmailMessage{
+		From:    "from@test.com",
+		To:      []string{"to@test.com"},
+		Subject: "Test",
+	})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(mock.calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(mock.calls))
+	}
+	if mock.calls[0].Subject != "Test" {
+		t.Errorf("expected 'Test', got '%s'", mock.calls[0].Subject)
+	}
+}
+
+func TestSendEmailUnsupportedPlatform(t *testing.T) {
+	oldImpl := impl
+	impl = &emailServiceImpl{
+		clients: make(map[string]iEmail),
+	}
+	defer func() { impl = oldImpl }()
+
+	err := SendEmail("unknown", &EmailMessage{})
+	if err == nil {
+		t.Error("expected error for unsupported platform")
+	}
+	if err.Error() != "unsupported email platform" {
+		t.Errorf("expected 'unsupported email platform', got '%s'", err.Error())
+	}
+}
+
+func TestSendEmailError(t *testing.T) {
+	oldImpl := impl
+	impl = &emailServiceImpl{
+		clients: make(map[string]iEmail),
+	}
+	defer func() { impl = oldImpl }()
+
+	mock := &mockEmailClient{err: errors.New("smtp error")}
+	Register("fail-platform", mock)
+
+	err := SendEmail("fail-platform", &EmailMessage{})
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestEmailMessageFields(t *testing.T) {
+	msg := EmailMessage{
+		From:       "sender@test.com",
+		To:         []string{"a@test.com", "b@test.com"},
+		Subject:    "Subject",
+		Attachment: "/path/to/file",
+		MIME:       "text/html",
+		HasSecret:  true,
+	}
+	if msg.From != "sender@test.com" {
+		t.Errorf("expected 'sender@test.com', got '%s'", msg.From)
+	}
+	if len(msg.To) != 2 {
+		t.Errorf("expected 2 recipients, got %d", len(msg.To))
+	}
+}

--- a/signing/domain/error_test.go
+++ b/signing/domain/error_test.go
@@ -1,0 +1,113 @@
+package domain
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestNewDomainError(t *testing.T) {
+	e := NewDomainError(ErrorCodeUserFrozen)
+	if e.Error() != "user frozen" {
+		t.Errorf("expected 'user frozen', got '%s'", e.Error())
+	}
+	if e.ErrorCode() != ErrorCodeUserFrozen {
+		t.Errorf("expected '%s', got '%s'", ErrorCodeUserFrozen, e.ErrorCode())
+	}
+}
+
+func TestNewNotFoundDomainError(t *testing.T) {
+	e := NewNotFoundDomainError(ErrorCodeUserNotExists)
+	if e.Error() != "user not exists" {
+		t.Errorf("expected 'user not exists', got '%s'", e.Error())
+	}
+	if !e.NotFound() {
+		t.Error("expected NotFound() to return true")
+	}
+	if e.ErrorCode() != ErrorCodeUserNotExists {
+		t.Errorf("expected '%s', got '%s'", ErrorCodeUserNotExists, e.ErrorCode())
+	}
+}
+
+func TestIsErrorOf(t *testing.T) {
+	e := NewDomainError(ErrorCodeUserFrozen)
+	if !IsErrorOf(e, ErrorCodeUserFrozen) {
+		t.Error("expected IsErrorOf to return true")
+	}
+	if IsErrorOf(e, ErrorCodeUserExists) {
+		t.Error("expected IsErrorOf to return false for different code")
+	}
+	if IsErrorOf(errors.New("plain error"), ErrorCodeUserFrozen) {
+		t.Error("expected IsErrorOf to return false for plain error")
+	}
+}
+
+func TestDomainErrorFormatsUnderscores(t *testing.T) {
+	e := NewDomainError("user_wrong_account_or_password")
+	if e.Error() != "user wrong account or password" {
+		t.Errorf("expected underscores replaced, got '%s'", e.Error())
+	}
+}
+
+func TestDomainErrorErrorInterface(t *testing.T) {
+	var _ error = NewDomainError("test")
+	var _ error = NewNotFoundDomainError("test")
+}
+
+func TestDomainErrorAllCodes(t *testing.T) {
+	codes := []string{
+		ErrorCodeUserFrozen,
+		ErrorCodeUserExists,
+		ErrorCodeUserNotExists,
+		ErrorCodeUserSamePassword,
+		ErrorPrivacyConsentInvalid,
+		ErrorCodeUserInvalidAccount,
+		ErrorCodeUserInvalidPassword,
+		ErrorCodeUserUnmatchedPassword,
+		ErrorCodeUserWrongAccountOrPassword,
+		ErrorCodeCorpAdminExists,
+		ErrorCodeCorpPDFNotFound,
+		ErrorCodeCorpSigningNotFound,
+		ErrorCodeCorpSigningReSigning,
+		ErrorCodeCorpSigningCanNotDelete,
+		ErrorCodeCorpSigningCLAIsLatest,
+		ErrorCodeCorpEmailDomainExists,
+		ErrorCodeCorpEmailDomainNotMatch,
+		ErrorCodeEmployeeManagerExists,
+		ErrorCodeEmployeeManagerTooMany,
+		ErrorCodeEmployeeManagerNotExists,
+		ErrorCodeEmployeeManagerNotSameCorp,
+		ErrorCodeEmployeeManagerAdminAsManager,
+		ErrorCodeEmployeeNotSameCorp,
+		ErrorCodeEmployeeSigningNotFound,
+		ErrorCodeEmployeeSigningReSigning,
+		ErrorCodeEmployeeSigningNoManager,
+		ErrorCodeEmployeeSigningEnableAgain,
+		ErrorCodeEmployeeSigningDisableAgain,
+		ErrorCodeEmployeeSigningCanNotDelete,
+		ErrorCodeIndividualSigningReSigning,
+		ErrorCodeIndividualSigningCorpExists,
+		ErrorCodeIndividualSigningCLAIsLatest,
+		ErrorCodeVerificationCodeBusy,
+		ErrorCodeVerificationCodeWrong,
+		ErrorCodeEmailCredentialNotFound,
+		ErrorCodeGmailNoRefreshToken,
+		ErrorCodeAccessTokenInvalid,
+		ErrorCodeCaptchaInvalid,
+		ErrorCodeCLAExists,
+		ErrorCodeCLANotExists,
+		ErrorCodeCLACanNotRemove,
+		ErrorCodeLinkExists,
+		ErrorCodeLinkNotExists,
+		ErrorCodeLinkCanNotRemove,
+		ErrorCodeNoPermission,
+		ErrorCodeLinkCanNotMigrate,
+	}
+	for _, code := range codes {
+		e := NewDomainError(code)
+		if e.ErrorCode() != code {
+			t.Errorf("ErrorCode mismatch for %s", code)
+		}
+		_ = fmt.Sprint(e)
+	}
+}

--- a/signing/domain/loginservice/loginservice_test.go
+++ b/signing/domain/loginservice/loginservice_test.go
@@ -1,0 +1,212 @@
+package loginservice
+
+import (
+	"testing"
+
+	commonRepo "github.com/opensourceways/app-cla-server/common/domain/repository"
+	"github.com/opensourceways/app-cla-server/signing/domain"
+	"github.com/opensourceways/app-cla-server/signing/domain/dp"
+	"github.com/opensourceways/app-cla-server/signing/domain/encryption"
+	"github.com/opensourceways/app-cla-server/signing/domain/repository"
+	"github.com/opensourceways/app-cla-server/signing/domain/userpassword"
+)
+
+func init() {
+	// Setup domain config with login settings
+	domain.Init(&domain.Config{
+		MaxNumOfFailedLogin:  5,
+		NeedCaptchaThreshold: 1,
+	})
+}
+
+type mockUserRepo struct {
+	findByAccountRes domain.User
+	findByAccountErr error
+	findByEmailRes   domain.User
+	findByEmailErr   error
+}
+
+func (m *mockUserRepo) Find(string) (domain.User, error)                      { return domain.User{}, nil }
+func (m *mockUserRepo) FindByAccount(linkId string, a dp.Account) (domain.User, error) {
+	return m.findByAccountRes, m.findByAccountErr
+}
+func (m *mockUserRepo) FindByEmail(linkId string, e dp.EmailAddr) (domain.User, error) {
+	return m.findByEmailRes, m.findByEmailErr
+}
+func (m *mockUserRepo) FindAllByLinkId(string) ([]domain.User, error)          { return nil, nil }
+func (m *mockUserRepo) Add(*domain.User) (string, error)                       { return "", nil }
+func (m *mockUserRepo) AddForMigrate(*domain.User) (string, error)             { return "", nil }
+func (m *mockUserRepo) Remove([]string) error                                  { return nil }
+func (m *mockUserRepo) RemoveByAccount(string, []dp.Account) error            { return nil }
+func (m *mockUserRepo) SavePassword(*domain.User) error                        { return nil }
+func (m *mockUserRepo) SavePrivacyConsent(*domain.User) error                  { return nil }
+
+type mockLoginRepo struct {
+	findRes domain.Login
+	findErr error
+	addErr  error
+	delErr  error
+}
+
+func (m *mockLoginRepo) Add(l *domain.Login) error { return m.addErr }
+func (m *mockLoginRepo) Find(key string) (domain.Login, error) {
+	return m.findRes, m.findErr
+}
+func (m *mockLoginRepo) Delete(key string) error { return m.delErr }
+
+type mockEncrypt struct {
+	isSameVal   bool
+	encryptRes  []byte
+	encryptErr  error
+}
+
+func (m *mockEncrypt) Encrypt(v []byte) ([]byte, error) { return m.encryptRes, m.encryptErr }
+func (m *mockEncrypt) IsSame(plain, encrypted []byte) bool {
+	return m.isSameVal
+}
+
+type mockPassword struct {
+	valid bool
+}
+
+func (m *mockPassword) New() (dp.Password, error) { return dp.NewPassword([]byte("new")) }
+func (m *mockPassword) IsValid(dp.Password) bool   { return m.valid }
+
+func TestNewLoginService(t *testing.T) {
+	s := NewLoginService(&mockUserRepo{}, &mockLoginRepo{}, &mockEncrypt{}, &mockPassword{})
+	if s == nil {
+		t.Fatal("expected non-nil")
+	}
+}
+
+func TestLoginByAccountSuccess(t *testing.T) {
+	pw, _ := dp.NewPassword([]byte("correct"))
+	encPassword := []byte("encrypted-password")
+
+	userRepo := &mockUserRepo{
+		findByAccountRes: domain.User{
+			UserBasicInfo: domain.UserBasicInfo{Password: encPassword},
+		},
+	}
+	loginRepo := &mockLoginRepo{
+		findErr: commonRepo.NewErrorResourceNotFound(nil),
+	}
+	encrypt := &mockEncrypt{isSameVal: true}
+	password := &mockPassword{valid: true}
+
+	s := NewLoginService(userRepo, loginRepo, encrypt, password)
+	u, lv, err := s.LoginByAccount("link1", dp.CreateAccount("user"), pw)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	_ = u
+	_ = lv
+}
+
+func TestLoginByAccountWrongPassword(t *testing.T) {
+	pw, _ := dp.NewPassword([]byte("wrong"))
+	encPassword := []byte("encrypted-password")
+
+	userRepo := &mockUserRepo{
+		findByAccountRes: domain.User{
+			UserBasicInfo: domain.UserBasicInfo{Password: encPassword},
+		},
+	}
+	loginRepo := &mockLoginRepo{
+		findErr: commonRepo.NewErrorResourceNotFound(nil),
+	}
+	encrypt := &mockEncrypt{isSameVal: false} // wrong password
+	password := &mockPassword{valid: true}
+
+	s := NewLoginService(userRepo, loginRepo, encrypt, password)
+	_, _, err := s.LoginByAccount("link1", dp.CreateAccount("user"), pw)
+	if err == nil {
+		t.Error("expected error for wrong password")
+	}
+}
+
+func TestLoginByAccountFrozen(t *testing.T) {
+	pw, _ := dp.NewPassword([]byte("correct"))
+
+	loginRepo := &mockLoginRepo{
+		findRes: domain.Login{Frozen: true},
+	}
+	password := &mockPassword{valid: true}
+
+	s := NewLoginService(&mockUserRepo{}, loginRepo, &mockEncrypt{}, password)
+	_, _, err := s.LoginByAccount("link1", dp.CreateAccount("user"), pw)
+	if err == nil {
+		t.Error("expected error for frozen login")
+	}
+}
+
+func TestNeedCaptcha(t *testing.T) {
+	loginRepo := &mockLoginRepo{
+		findRes: domain.Login{FailedNum: 2}, // threshold is 1, so NeedCaptcha = true
+	}
+	s := NewLoginService(nil, loginRepo, nil, nil)
+	b, err := s.NeedCaptcha("test-id")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !b {
+		t.Error("expected captcha needed")
+	}
+}
+
+func TestNeedCaptchaNotFound(t *testing.T) {
+	loginRepo := &mockLoginRepo{
+		findErr: commonRepo.NewErrorResourceNotFound(nil),
+	}
+	s := NewLoginService(nil, loginRepo, nil, nil)
+	b, err := s.NeedCaptcha("test-id")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if b {
+		t.Error("expected no captcha for not found")
+	}
+}
+
+func TestClearLoginFailure(t *testing.T) {
+	loginRepo := &mockLoginRepo{}
+	s := NewLoginService(nil, loginRepo, nil, nil)
+	if err := s.ClearLoginFailure("test-id"); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestGetLoginInfo(t *testing.T) {
+	loginRepo := &mockLoginRepo{
+		findRes: domain.Login{Id: "test", FailedNum: 2},
+	}
+	s := NewLoginService(nil, loginRepo, nil, nil)
+	lv, err := s.GetLoginInfo("test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if lv == nil || lv.FailedNum != 2 {
+		t.Errorf("expected FailedNum=2, got %+v", lv)
+	}
+}
+
+func TestGetLoginInfoNotFound(t *testing.T) {
+	loginRepo := &mockLoginRepo{
+		findErr: commonRepo.NewErrorResourceNotFound(nil),
+	}
+	s := NewLoginService(nil, loginRepo, nil, nil)
+	lv, err := s.GetLoginInfo("test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if lv != nil {
+		t.Error("expected nil for not found")
+	}
+}
+
+// Verify interface compliance
+var _ LoginService = (*loginService)(nil)
+var _ repository.User = (*mockUserRepo)(nil)
+var _ repository.Login = (*mockLoginRepo)(nil)
+var _ encryption.Encryption = (*mockEncrypt)(nil)
+var _ userpassword.UserPassword = (*mockPassword)(nil)

--- a/signing/infrastructure/accesstokenimpl/access_token_do_test.go
+++ b/signing/infrastructure/accesstokenimpl/access_token_do_test.go
@@ -1,0 +1,63 @@
+package accesstokenimpl
+
+import (
+	"testing"
+
+	"github.com/opensourceways/app-cla-server/signing/domain"
+)
+
+func TestToAccessTokenDo(t *testing.T) {
+	at := &domain.AccessToken{
+		Expiry:        100,
+		Payload:       []byte("payload"),
+		EncryptedCSRF: []byte("csrf"),
+	}
+	do := toAccessTokenDo(at)
+	if do.Expiry != 100 {
+		t.Errorf("expected 100, got %d", do.Expiry)
+	}
+	if string(do.Payload) != "payload" {
+		t.Errorf("expected 'payload', got '%s'", string(do.Payload))
+	}
+	if string(do.EncryptedCSRF) != "csrf" {
+		t.Errorf("expected 'csrf', got '%s'", string(do.EncryptedCSRF))
+	}
+}
+
+func TestAccessTokenDOToAccessToken(t *testing.T) {
+	do := &accessTokenDO{
+		Expiry:        200,
+		Payload:       []byte("p"),
+		EncryptedCSRF: []byte("c"),
+	}
+	at := do.toAccessToken()
+	if at.Expiry != 200 {
+		t.Errorf("expected 200, got %d", at.Expiry)
+	}
+	if string(at.Payload) != "p" {
+		t.Errorf("expected 'p', got '%s'", string(at.Payload))
+	}
+}
+
+func TestMarshalUnmarshalBinary(t *testing.T) {
+	do := &accessTokenDO{
+		Expiry:        300,
+		Payload:       []byte("test-payload"),
+		EncryptedCSRF: []byte("test-csrf"),
+	}
+	data, err := do.MarshalBinary()
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var do2 accessTokenDO
+	if err := do2.UnmarshalBinary(data); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if do2.Expiry != do.Expiry {
+		t.Errorf("expected %d, got %d", do.Expiry, do2.Expiry)
+	}
+	if string(do2.Payload) != string(do.Payload) {
+		t.Errorf("payload mismatch: '%s' vs '%s'", do2.Payload, do.Payload)
+	}
+}

--- a/signing/infrastructure/accesstokenimpl/accesstokenimpl_mock_test.go
+++ b/signing/infrastructure/accesstokenimpl/accesstokenimpl_mock_test.go
@@ -1,0 +1,70 @@
+package accesstokenimpl
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/opensourceways/app-cla-server/signing/domain"
+)
+
+type mockAccessTokenDao struct {
+	setErr       error
+	getVal       interface{}
+	getErr       error
+	expireErr    error
+	isNotExists  bool
+}
+
+func (m *mockAccessTokenDao) Set(key string, val interface{}) error     { return m.setErr }
+func (m *mockAccessTokenDao) Get(key string, val interface{}) error     { return m.getErr }
+func (m *mockAccessTokenDao) Expire(key string, d time.Duration) error  { return m.expireErr }
+func (m *mockAccessTokenDao) IsDocNotExists(err error) bool              { return m.isNotExists }
+
+func TestAccessTokenImplAdd(t *testing.T) {
+	dao := &mockAccessTokenDao{}
+	impl := &accessTokenImpl{dao: dao, expiry: time.Second}
+
+	at := &domain.AccessToken{
+		Expiry:        1000,
+		Payload:       []byte("payload"),
+		EncryptedCSRF: []byte("csrf"),
+	}
+	key, err := impl.Add(at)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if key == "" {
+		t.Error("expected non-empty key")
+	}
+}
+
+func TestAccessTokenImplFind(t *testing.T) {
+	// We can't easily test Find without real serialization in redis,
+	// but we can test the error paths
+	dao := &mockAccessTokenDao{getErr: errors.New("not found"), isNotExists: true}
+	impl := &accessTokenImpl{dao: dao}
+	_, err := impl.Find("key")
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestAccessTokenImplDelete(t *testing.T) {
+	dao := &mockAccessTokenDao{}
+	impl := &accessTokenImpl{dao: dao, expiry: time.Second}
+	if err := impl.Delete("key"); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNewAccessTokenImpl(t *testing.T) {
+	cfg := &Config{Expire: 120}
+	impl := NewAccessTokenImpl(&mockAccessTokenDao{}, cfg)
+	if impl == nil {
+		t.Fatal("expected non-nil")
+	}
+	if impl.expiry != 120*time.Second {
+		t.Errorf("expected 120s, got %v", impl.expiry)
+	}
+}

--- a/signing/infrastructure/accesstokenimpl/config_test.go
+++ b/signing/infrastructure/accesstokenimpl/config_test.go
@@ -1,0 +1,25 @@
+package accesstokenimpl
+
+import (
+	"testing"
+	"time"
+)
+
+func TestConfigSetDefault(t *testing.T) {
+	cfg := &Config{}
+	cfg.SetDefault()
+	if cfg.Expire != 60 {
+		t.Errorf("expected 60, got %d", cfg.Expire)
+	}
+	if cfg.expire() != 60*time.Second {
+		t.Errorf("expected 60s, got %v", cfg.expire())
+	}
+}
+
+func TestConfigSetDefaultKeepsCustom(t *testing.T) {
+	cfg := &Config{Expire: 120}
+	cfg.SetDefault()
+	if cfg.Expire != 120 {
+		t.Errorf("expected 120, got %d", cfg.Expire)
+	}
+}

--- a/signing/infrastructure/captchaimpl/captchaimpl_test.go
+++ b/signing/infrastructure/captchaimpl/captchaimpl_test.go
@@ -1,0 +1,34 @@
+package captchaimpl
+
+import (
+	"testing"
+)
+
+func TestCaptchaImplStruct(t *testing.T) {
+	c := &captchaImpl{
+		isTestEnv:  true,
+		testAnswer: "123456",
+	}
+	if !c.isTestEnv {
+		t.Error("expected isTestEnv=true")
+	}
+	if c.testAnswer != "123456" {
+		t.Errorf("expected '123456', got '%s'", c.testAnswer)
+	}
+}
+
+func TestVerifyEmptyInput(t *testing.T) {
+	c := &captchaImpl{}
+	err := c.Verify("", "")
+	if err == nil {
+		t.Error("expected error for empty input")
+	}
+	err = c.Verify("id", "")
+	if err == nil {
+		t.Error("expected error for empty answer")
+	}
+	err = c.Verify("", "answer")
+	if err == nil {
+		t.Error("expected error for empty id")
+	}
+}

--- a/signing/infrastructure/captchaimpl/config_test.go
+++ b/signing/infrastructure/captchaimpl/config_test.go
@@ -1,0 +1,47 @@
+package captchaimpl
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCaptchaConfigSetDefault(t *testing.T) {
+	cfg := &Config{}
+	cfg.SetDefault()
+	if cfg.Expiry != 300 {
+		t.Errorf("expected 300, got %d", cfg.Expiry)
+	}
+	if cfg.Height != 80 {
+		t.Errorf("expected 80, got %d", cfg.Height)
+	}
+	if cfg.Width != 240 {
+		t.Errorf("expected 240, got %d", cfg.Width)
+	}
+	if cfg.Length != 6 {
+		t.Errorf("expected 6, got %d", cfg.Length)
+	}
+	if cfg.NoiseLevel != 0.7 {
+		t.Errorf("expected 0.7, got %f", cfg.NoiseLevel)
+	}
+	if cfg.BackgroundCircles != 80 {
+		t.Errorf("expected 80, got %d", cfg.BackgroundCircles)
+	}
+	if cfg.expiry() != 300*time.Second {
+		t.Errorf("expected 5m, got %v", cfg.expiry())
+	}
+}
+
+func TestCaptchaConfigSetDefaultKeepsCustom(t *testing.T) {
+	cfg := &Config{
+		Expiry:            600,
+		Height:            100,
+		Width:             320,
+		Length:            4,
+		NoiseLevel:        0.5,
+		BackgroundCircles: 40,
+	}
+	cfg.SetDefault()
+	if cfg.Expiry != 600 || cfg.Height != 100 || cfg.Length != 4 {
+		t.Errorf("custom values not preserved")
+	}
+}

--- a/signing/infrastructure/emailtmpl/emailtmpl_test.go
+++ b/signing/infrastructure/emailtmpl/emailtmpl_test.go
@@ -1,0 +1,248 @@
+package emailtmpl
+
+import (
+	"text/template"
+	"testing"
+)
+
+func TestFindTmpl(t *testing.T) {
+	// Save original and restore
+	orig := msgTmpl
+	msgTmpl = map[string]*template.Template{
+		TmplCorporationSigning: template.Must(template.New("test").Parse("Hello {{.Org}}")),
+	}
+	defer func() { msgTmpl = orig }()
+
+	tmpl := findTmpl(TmplCorporationSigning)
+	if tmpl == nil {
+		t.Error("expected to find template")
+	}
+
+	tmpl = findTmpl("nonexistent")
+	if tmpl != nil {
+		t.Error("expected nil for nonexistent template")
+	}
+}
+
+func TestGenEmailMsg(t *testing.T) {
+	orig := msgTmpl
+	msgTmpl = map[string]*template.Template{
+		TmplCorporationSigning: template.Must(template.New("test").Parse("Org: {{.Org}}")),
+	}
+	defer func() { msgTmpl = orig }()
+
+	msg, err := genEmailMsg(TmplCorporationSigning, struct{ Org string }{Org: "TestOrg"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msg.Content.String() != "Org: TestOrg" {
+		t.Errorf("expected 'Org: TestOrg', got '%s'", msg.Content.String())
+	}
+}
+
+func TestGenEmailMsgMissingTemplate(t *testing.T) {
+	orig := msgTmpl
+	msgTmpl = map[string]*template.Template{}
+	defer func() { msgTmpl = orig }()
+
+	_, err := genEmailMsg("nonexistent", nil)
+	if err == nil {
+		t.Error("expected error for missing template")
+	}
+}
+
+func TestCorporationSigningGenEmailMsg(t *testing.T) {
+	orig := msgTmpl
+	msgTmpl = map[string]*template.Template{
+		TmplCorporationSigning: template.Must(template.New("test").Parse("{{.Org}} - {{.Date}}")),
+	}
+	defer func() { msgTmpl = orig }()
+
+	data := &CorporationSigning{Org: "Org1", Date: "2024-01-01"}
+	msg, err := data.GenEmailMsg()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msg.Content.String() != "Org1 - 2024-01-01" {
+		t.Errorf("unexpected content: %s", msg.Content.String())
+	}
+}
+
+func TestIndividualSigningGenEmailMsg(t *testing.T) {
+	orig := msgTmpl
+	msgTmpl = map[string]*template.Template{
+		TmplIndividualSigning: template.Must(template.New("test").Parse("Name: {{.Name}}")),
+	}
+	defer func() { msgTmpl = orig }()
+
+	data := &IndividualSigning{Name: "John"}
+	msg, err := data.GenEmailMsg()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msg.Content.String() != "Name: John" {
+		t.Errorf("unexpected content: %s", msg.Content.String())
+	}
+}
+
+func TestVerificationCodeGenEmailMsg(t *testing.T) {
+	orig := msgTmpl
+	msgTmpl = map[string]*template.Template{
+		TmplVerificationCode: template.Must(template.New("test").Parse("{{.Code}}")),
+	}
+	defer func() { msgTmpl = orig }()
+
+	data := &VerificationCode{Code: "123456"}
+	msg, err := data.GenEmailMsg()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msg.Content.String() != "123456" {
+		t.Errorf("unexpected content: %s", msg.Content.String())
+	}
+}
+
+func TestAddingCorpManagerAdmin(t *testing.T) {
+	orig := msgTmpl
+	msgTmpl = map[string]*template.Template{
+		TmplAddingCorpAdmin: template.Must(template.New("test").Parse("Admin: {{.User}}")),
+	}
+	defer func() { msgTmpl = orig }()
+
+	data := &AddingCorpManager{Admin: true, User: "AdminUser"}
+	msg, err := data.GenEmailMsg()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !msg.HasSecret {
+		t.Error("expected HasSecret=true for admin")
+	}
+}
+
+func TestAddingCorpManagerNonAdmin(t *testing.T) {
+	orig := msgTmpl
+	msgTmpl = map[string]*template.Template{
+		TmplAddingCorpManager: template.Must(template.New("test").Parse("Manager: {{.User}}")),
+	}
+	defer func() { msgTmpl = orig }()
+
+	data := &AddingCorpManager{Admin: false, User: "MgrUser"}
+	msg, err := data.GenEmailMsg()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !msg.HasSecret {
+		t.Error("expected HasSecret=true for manager")
+	}
+}
+
+func TestEmployeeNotificationActive(t *testing.T) {
+	orig := msgTmpl
+	msgTmpl = map[string]*template.Template{
+		TmplActivatingEmployee: template.Must(template.New("test").Parse("Active: {{.Name}}")),
+	}
+	defer func() { msgTmpl = orig }()
+
+	data := &EmployeeNotification{Active: true, Name: "Emp1"}
+	msg, err := data.GenEmailMsg()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msg.Content.String() != "Active: Emp1" {
+		t.Errorf("unexpected content: %s", msg.Content.String())
+	}
+}
+
+func TestEmployeeNotificationInactive(t *testing.T) {
+	orig := msgTmpl
+	msgTmpl = map[string]*template.Template{
+		TmplInactivaingEmployee: template.Must(template.New("test").Parse("Inactive: {{.Name}}")),
+	}
+	defer func() { msgTmpl = orig }()
+
+	data := &EmployeeNotification{Inactive: true, Name: "Emp2"}
+	msg, err := data.GenEmailMsg()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msg.Content.String() != "Inactive: Emp2" {
+		t.Errorf("unexpected content: %s", msg.Content.String())
+	}
+}
+
+func TestEmployeeNotificationRemoving(t *testing.T) {
+	orig := msgTmpl
+	msgTmpl = map[string]*template.Template{
+		TmplRemovingingEmployee: template.Must(template.New("test").Parse("Removed: {{.Name}}")),
+	}
+	defer func() { msgTmpl = orig }()
+
+	data := &EmployeeNotification{Removing: true, Name: "Emp3"}
+	msg, err := data.GenEmailMsg()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msg.Content.String() != "Removed: Emp3" {
+		t.Errorf("unexpected content: %s", msg.Content.String())
+	}
+}
+
+func TestEmployeeNotificationNoAction(t *testing.T) {
+	data := &EmployeeNotification{}
+	_, err := data.GenEmailMsg()
+	if err == nil {
+		t.Error("expected error for no action")
+	}
+}
+
+func TestPasswordRetrievalGenEmailMsg(t *testing.T) {
+	orig := msgTmpl
+	msgTmpl = map[string]*template.Template{
+		TmplPasswordRetrieval: template.Must(template.New("test").Parse("Reset: {{.ResetURL}}")),
+	}
+	defer func() { msgTmpl = orig }()
+
+	data := PasswordRetrieval{ResetURL: "https://reset.example.com"}
+	msg, err := data.GenEmailMsg()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msg.MIME == "" {
+		t.Error("expected MIME to be set for password retrieval")
+	}
+	if msg.Content.String() != "Reset: https://reset.example.com" {
+		t.Errorf("unexpected content: %s", msg.Content.String())
+	}
+}
+
+func TestCLAUpdatedGenEmailMsg(t *testing.T) {
+	orig := msgTmpl
+	msgTmpl = map[string]*template.Template{
+		TmplCLAUpdated: template.Must(template.New("test").Parse("CLA: {{.Org}}")),
+	}
+	defer func() { msgTmpl = orig }()
+
+	data := &CLAUpdated{Org: "TestOrg"}
+	msg, err := data.GenEmailMsg()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msg.Content.String() != "CLA: TestOrg" {
+		t.Errorf("unexpected content: %s", msg.Content.String())
+	}
+}
+
+func TestAllTemplateConstants(t *testing.T) {
+	names := []string{
+		TmplCorporationSigning, TmplIndividualSigning, TmplEmployeeSigning,
+		TmplNotifyingManager, TmplVerificationCode, TmplAddingCorpEmailDomain,
+		TmplAddingCorpAdmin, TmplAddingCorpManager, TmplRemovingCorpManager,
+		TmplActivatingEmployee, TmplInactivaingEmployee, TmplRemovingingEmployee,
+		TmplPasswordRetrieval, TmplEmailVerification, TmplCLAUpdated,
+	}
+	for _, name := range names {
+		if name == "" {
+			t.Error("empty template name constant")
+		}
+	}
+}

--- a/signing/infrastructure/encryptionimpl/encryptionimpl_test.go
+++ b/signing/infrastructure/encryptionimpl/encryptionimpl_test.go
@@ -1,0 +1,45 @@
+package encryptionimpl
+
+import (
+	"testing"
+)
+
+func TestEncryptDecrypt(t *testing.T) {
+	impl := NewEncryptionImpl()
+
+	plaintext := []byte("test password")
+	encrypted, err := impl.Encrypt(plaintext)
+	if err != nil {
+		t.Fatalf("encrypt error: %v", err)
+	}
+
+	if len(encrypted) <= saltLen {
+		t.Error("encrypted data should include salt")
+	}
+
+	if !impl.IsSame(plaintext, encrypted) {
+		t.Error("expected IsSame to return true")
+	}
+
+	if impl.IsSame([]byte("wrong"), encrypted) {
+		t.Error("expected IsSame to return false for wrong plaintext")
+	}
+}
+
+func TestIsSameShortCiphertext(t *testing.T) {
+	impl := NewEncryptionImpl()
+
+	// ciphertext shorter than saltLen+1
+	if impl.IsSame([]byte("test"), []byte("short")) {
+		t.Error("expected false for short ciphertext")
+	}
+}
+
+func TestNewEncryptionImpl(t *testing.T) {
+	impl := NewEncryptionImpl()
+	// encryptionImpl is a struct value, verify it can encrypt/decrypt
+	_, err := impl.Encrypt([]byte("test"))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/signing/infrastructure/limiterimpl/limiterimpl_test.go
+++ b/signing/infrastructure/limiterimpl/limiterimpl_test.go
@@ -1,0 +1,48 @@
+package limiterimpl
+
+import (
+	"testing"
+	"time"
+)
+
+type mockLimiterDao struct {
+	setKeyErr   error
+	hasKeyRes   bool
+	hasKeyErr   error
+}
+
+func (m *mockLimiterDao) SetKey(k string, expiry time.Duration) error { return m.setKeyErr }
+func (m *mockLimiterDao) HasKey(k string) (bool, error)               { return m.hasKeyRes, m.hasKeyErr }
+
+func TestNewLimiterImpl(t *testing.T) {
+	impl := NewLimiterImpl(&mockLimiterDao{})
+	if impl == nil {
+		t.Fatal("expected non-nil")
+	}
+}
+
+func TestLimiterAdd(t *testing.T) {
+	impl := &limiterImpl{dao: &mockLimiterDao{}}
+	if err := impl.Add("key", time.Second); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestLimiterIsAllowed(t *testing.T) {
+	// Key doesn't exist → allowed
+	impl := &limiterImpl{dao: &mockLimiterDao{hasKeyRes: false}}
+	allowed, err := impl.IsAllowed("key")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !allowed {
+		t.Error("expected allowed")
+	}
+
+	// Key exists → not allowed
+	impl2 := &limiterImpl{dao: &mockLimiterDao{hasKeyRes: true}}
+	allowed2, _ := impl2.IsAllowed("key")
+	if allowed2 {
+		t.Error("expected not allowed")
+	}
+}

--- a/signing/infrastructure/localclaimpl/localclaimpl_test.go
+++ b/signing/infrastructure/localclaimpl/localclaimpl_test.go
@@ -1,0 +1,52 @@
+package localclaimpl
+
+import (
+	"testing"
+
+	"github.com/opensourceways/app-cla-server/signing/domain"
+)
+
+func TestLocalPath(t *testing.T) {
+	impl := &localCLAImpl{dir: "/tmp/cla"}
+	p := impl.localPath("link1", "cla1")
+	if p != "/tmp/cla/link1_cla1.pdf" {
+		t.Errorf("expected '/tmp/cla/link1_cla1.pdf', got '%s'", p)
+	}
+}
+
+func TestLocalPathOfDiff(t *testing.T) {
+	impl := &localCLAImpl{dir: "/tmp/cla"}
+	index := &domain.CLAIndex{LinkId: "L1", CLAId: "C2"}
+	p := impl.LocalPathOfDiff(index, "signed1")
+	if p != "/tmp/cla/L1_signed1_C2.txt" {
+		t.Errorf("expected '/tmp/cla/L1_signed1_C2.txt', got '%s'", p)
+	}
+}
+
+func TestLocalPathOfDiff2(t *testing.T) {
+	// Verify the method is consistent
+	impl := &localCLAImpl{dir: "/data/cla"}
+	index := &domain.CLAIndex{LinkId: "link-123", CLAId: "cla-456"}
+	p := impl.LocalPathOfDiff(index, "old789")
+	if p != "/data/cla/link-123_old789_cla-456.txt" {
+		t.Errorf("expected '/data/cla/link-123_old789_cla-456.txt', got '%s'", p)
+	}
+}
+
+func TestLocalPath2(t *testing.T) {
+	impl := &localCLAImpl{dir: "/var/lib/cla"}
+	p := impl.localPath("abc", "001")
+	if p != "/var/lib/cla/abc_001.pdf" {
+		t.Errorf("expected '/var/lib/cla/abc_001.pdf', got '%s'", p)
+	}
+}
+
+func TestNewLocalCLAImpl(t *testing.T) {
+	impl := NewLocalCLAImpl(&Config{Dir: "/tmp"})
+	if impl == nil {
+		t.Fatal("expected non-nil")
+	}
+	if impl.dir != "/tmp" {
+		t.Errorf("expected '/tmp', got '%s'", impl.dir)
+	}
+}

--- a/signing/infrastructure/loginimpl/loginimpl_mock_test.go
+++ b/signing/infrastructure/loginimpl/loginimpl_mock_test.go
@@ -1,0 +1,61 @@
+package loginimpl
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/opensourceways/app-cla-server/signing/domain"
+)
+
+type mockLoginDao struct {
+	setErr      error
+	getErr      error
+	expireErr   error
+	isNotExists bool
+}
+
+func (m *mockLoginDao) SetWithExpiry(key string, val interface{}, expiry time.Duration) error {
+	return m.setErr
+}
+func (m *mockLoginDao) Get(key string, val interface{}) error     { return m.getErr }
+func (m *mockLoginDao) Expire(key string, d time.Duration) error  { return m.expireErr }
+func (m *mockLoginDao) IsDocNotExists(err error) bool              { return m.isNotExists }
+
+func TestLoginImplAdd(t *testing.T) {
+	dao := &mockLoginDao{}
+	impl := &loginImpl{dao: dao, expiry: time.Minute}
+
+	l := &domain.Login{Id: "test-id", Frozen: false, FailedNum: 2}
+	if err := impl.Add(l); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestLoginImplFind(t *testing.T) {
+	dao := &mockLoginDao{getErr: errors.New("not found"), isNotExists: true}
+	impl := &loginImpl{dao: dao}
+	_, err := impl.Find("key")
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestLoginImplDelete(t *testing.T) {
+	dao := &mockLoginDao{}
+	impl := &loginImpl{dao: dao}
+	if err := impl.Delete("key"); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNewLoginImpl(t *testing.T) {
+	cfg := &Config{Expire: 600}
+	impl := NewLoginImpl(&mockLoginDao{}, cfg)
+	if impl == nil {
+		t.Fatal("expected non-nil")
+	}
+	if impl.expiry != 600*time.Second {
+		t.Errorf("expected 600s, got %v", impl.expiry)
+	}
+}

--- a/signing/infrastructure/loginimpl/loginimpl_test.go
+++ b/signing/infrastructure/loginimpl/loginimpl_test.go
@@ -1,0 +1,83 @@
+package loginimpl
+
+import (
+	"testing"
+	"time"
+
+	"github.com/opensourceways/app-cla-server/signing/domain"
+)
+
+func TestConfigSetDefault(t *testing.T) {
+	cfg := &Config{}
+	cfg.SetDefault()
+	if cfg.Expire != 300 {
+		t.Errorf("expected 300, got %d", cfg.Expire)
+	}
+}
+
+func TestConfigSetDefaultKeepsCustom(t *testing.T) {
+	cfg := &Config{Expire: 600}
+	cfg.SetDefault()
+	if cfg.Expire != 600 {
+		t.Errorf("expected 600, got %d", cfg.Expire)
+	}
+}
+
+func TestConfigExpire(t *testing.T) {
+	cfg := &Config{Expire: 120}
+	d := cfg.expire()
+	if d != 120*time.Second {
+		t.Errorf("expected 120s, got %v", d)
+	}
+}
+
+func TestToLoginDo(t *testing.T) {
+	l := &domain.Login{
+		Id:        "test-id",
+		Frozen:    true,
+		FailedNum: 3,
+	}
+	do := toLoginDo(l)
+	if !do.Frozen {
+		t.Error("expected Frozen=true")
+	}
+	if do.FailedNum != 3 {
+		t.Errorf("expected 3, got %d", do.FailedNum)
+	}
+}
+
+func TestLoginDOToLogin(t *testing.T) {
+	do := &loginDO{
+		Frozen:    true,
+		FailedNum: 5,
+	}
+	l := do.toLogin("my-id")
+	if l.Id != "my-id" {
+		t.Errorf("expected 'my-id', got '%s'", l.Id)
+	}
+	if !l.Frozen {
+		t.Error("expected Frozen=true")
+	}
+	if l.FailedNum != 5 {
+		t.Errorf("expected 5, got %d", l.FailedNum)
+	}
+}
+
+func TestMarshalUnmarshalBinary(t *testing.T) {
+	do := &loginDO{
+		Frozen:    true,
+		FailedNum: 4,
+	}
+	data, err := do.MarshalBinary()
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var do2 loginDO
+	if err := do2.UnmarshalBinary(data); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if do2.Frozen != do.Frozen || do2.FailedNum != do.FailedNum {
+		t.Errorf("mismatch: %+v vs %+v", do, do2)
+	}
+}

--- a/signing/infrastructure/passwordimpl/passwordimpl_test.go
+++ b/signing/infrastructure/passwordimpl/passwordimpl_test.go
@@ -1,0 +1,267 @@
+package passwordimpl
+
+import (
+	"testing"
+
+	"github.com/opensourceways/app-cla-server/signing/domain/dp"
+)
+
+func TestConfigSetDefault(t *testing.T) {
+	cfg := &Config{}
+	cfg.SetDefault()
+	if cfg.MinLength != 8 {
+		t.Errorf("expected 8, got %d", cfg.MinLength)
+	}
+	if cfg.MaxLength != 20 {
+		t.Errorf("expected 20, got %d", cfg.MaxLength)
+	}
+	if cfg.MaxNumOfConsecutiveChars != 2 {
+		t.Errorf("expected 2, got %d", cfg.MaxNumOfConsecutiveChars)
+	}
+	if cfg.MinNumOfKindOfPasswordChar != 3 {
+		t.Errorf("expected 3, got %d", cfg.MinNumOfKindOfPasswordChar)
+	}
+}
+
+func TestConfigSetDefaultKeepsCustom(t *testing.T) {
+	cfg := &Config{
+		MinLength:                  10,
+		MaxLength:                  30,
+		MaxNumOfConsecutiveChars:   3,
+		MinNumOfKindOfPasswordChar: 4,
+	}
+	cfg.SetDefault()
+	if cfg.MinLength != 10 {
+		t.Errorf("expected 10, got %d", cfg.MinLength)
+	}
+	if cfg.MinNumOfKindOfPasswordChar != 4 {
+		t.Errorf("expected 4, got %d", cfg.MinNumOfKindOfPasswordChar)
+	}
+}
+
+func TestHasMultiChars(t *testing.T) {
+	impl := &passwordImpl{
+		cfg: Config{MinNumOfKindOfPasswordChar: 3},
+	}
+
+	if !impl.hasMultiChars([]byte("Aa1!")) {
+		t.Error("expected true for mixed chars")
+	}
+	if !impl.hasMultiChars([]byte("Aa1aA1")) {
+		t.Error("expected true for mixed chars")
+	}
+	if impl.hasMultiChars([]byte("aaaaaa")) {
+		t.Error("expected false for all lowercase")
+	}
+	if impl.hasMultiChars([]byte("ABCDEF")) {
+		t.Error("expected false for all uppercase")
+	}
+	if impl.hasMultiChars([]byte("123456")) {
+		t.Error("expected false for all digits")
+	}
+}
+
+func TestMarkCharType(t *testing.T) {
+	impl := &passwordImpl{}
+
+	tests := []struct {
+		c    byte
+		idx  int
+		name string
+	}{
+		{'a', 0, "lowercase"},
+		{'z', 0, "lowercase"},
+		{'A', 1, "uppercase"},
+		{'Z', 1, "uppercase"},
+		{'0', 2, "digit"},
+		{'9', 2, "digit"},
+		{'!', 3, "special"},
+		{'@', 3, "special"},
+	}
+
+	for _, tt := range tests {
+		part := make([]bool, 4)
+		impl.markCharType(tt.c, part)
+		if !part[tt.idx] {
+			t.Errorf("expected part[%d] to be true for %s char '%c'", tt.idx, tt.name, tt.c)
+		}
+	}
+}
+
+func TestCountCharTypes(t *testing.T) {
+	impl := &passwordImpl{}
+
+	if n := impl.countCharTypes([]bool{true, false, false, false}); n != 1 {
+		t.Errorf("expected 1, got %d", n)
+	}
+	if n := impl.countCharTypes([]bool{true, true, true, false}); n != 3 {
+		t.Errorf("expected 3, got %d", n)
+	}
+	if n := impl.countCharTypes([]bool{true, true, true, true}); n != 4 {
+		t.Errorf("expected 4, got %d", n)
+	}
+	if n := impl.countCharTypes([]bool{false, false, false, false}); n != 0 {
+		t.Errorf("expected 0, got %d", n)
+	}
+}
+
+func TestHasConsecutive(t *testing.T) {
+	impl := &passwordImpl{
+		cfg: Config{MaxNumOfConsecutiveChars: 2},
+	}
+
+	// 3 consecutive a's > threshold 2, should be detected
+	if !impl.hasConsecutive([]byte("aaa")) {
+		t.Error("expected true for 'aaa' (3 consecutive)")
+	}
+	// 2 consecutive a's is not > 2, should not be detected
+	if impl.hasConsecutive([]byte("aa")) {
+		t.Error("expected false for 'aa' (2 consecutive, not > threshold)")
+	}
+	// 3 consecutive a's at start should still be detected
+	if !impl.hasConsecutive([]byte("aaabbb")) {
+		t.Error("expected true for 'aaabbb' (3 consecutive a's)")
+	}
+}
+
+func TestHasConsecutiveNoConsecutive(t *testing.T) {
+	impl := &passwordImpl{
+		cfg: Config{MaxNumOfConsecutiveChars: 2},
+	}
+	if impl.hasConsecutive([]byte("ababab")) {
+		t.Error("expected false for no consecutive")
+	}
+	if impl.hasConsecutive([]byte("a")) {
+		t.Error("expected false for single char")
+	}
+	if impl.hasConsecutive([]byte("")) {
+		t.Error("expected false for empty")
+	}
+}
+
+func TestGenChar(t *testing.T) {
+	impl := &passwordImpl{}
+	v := byte(100)
+
+	for i := 0; i < 3; i++ {
+		c := impl.genChar(i, v)
+		switch i % 3 {
+		case 0:
+			if c < 'a' || c > 'z' {
+				t.Errorf("genChar(0) expected lowercase, got '%c'", c)
+			}
+		case 1:
+			if c < 'A' || c > 'Z' {
+				t.Errorf("genChar(1) expected uppercase, got '%c'", c)
+			}
+		case 2:
+			if c < '0' || c > '9' {
+				t.Errorf("genChar(2) expected digit, got '%c'", c)
+			}
+		}
+	}
+}
+
+func TestIsValid(t *testing.T) {
+	impl := &passwordImpl{
+		cfg: Config{
+			MinLength:                  8,
+			MaxLength:                  20,
+			MaxNumOfConsecutiveChars:   2,
+			MinNumOfKindOfPasswordChar: 3,
+		},
+	}
+
+	validPw, _ := dp.NewPassword([]byte("Abc123!@"))
+	if !impl.IsValid(validPw) {
+		t.Error("expected valid password")
+	}
+
+	// Too short
+	shortPw, _ := dp.NewPassword([]byte("Ab1!"))
+	if impl.IsValid(shortPw) {
+		t.Error("expected invalid for too short")
+	}
+
+	// Too long
+	longBytes := make([]byte, 21)
+	for i := range longBytes {
+		longBytes[i] = 'a'
+	}
+	longPw, _ := dp.NewPassword(longBytes)
+	if impl.IsValid(longPw) {
+		t.Error("expected invalid for too long")
+	}
+
+	// Invalid characters (spaces)
+	spacePw, _ := dp.NewPassword([]byte("Abc 123!"))
+	if impl.IsValid(spacePw) {
+		t.Error("expected invalid for space character")
+	}
+}
+
+func TestIsValidNotEnoughCharTypes(t *testing.T) {
+	impl := &passwordImpl{
+		cfg: Config{
+			MinLength:                  4,
+			MaxLength:                  20,
+			MaxNumOfConsecutiveChars:   2,
+			MinNumOfKindOfPasswordChar: 3,
+		},
+	}
+	// Only lowercase and uppercase (2 types)
+	pw, _ := dp.NewPassword([]byte("AbcdEfgh"))
+	if impl.IsValid(pw) {
+		t.Error("expected invalid for only 2 char types")
+	}
+}
+
+func TestGoodFormat(t *testing.T) {
+	impl := &passwordImpl{
+		cfg: Config{
+			MaxNumOfConsecutiveChars:   2,
+			MinNumOfKindOfPasswordChar: 3,
+		},
+	}
+
+	if !impl.goodFormat([]byte("Abc123!@")) {
+		t.Error("expected good format")
+	}
+	if impl.goodFormat([]byte("aaa123!")) {
+		t.Error("expected bad format due to consecutive chars")
+	}
+}
+
+func TestNewPasswordImpl(t *testing.T) {
+	cfg := &Config{MinLength: 8, MaxLength: 20}
+	impl := NewPasswordImpl(cfg)
+	if impl == nil {
+		t.Fatal("expected non-nil")
+	}
+	if impl.cfg.MinLength != 8 {
+		t.Errorf("expected 8, got %d", impl.cfg.MinLength)
+	}
+}
+
+func TestPasswordNew(t *testing.T) {
+	impl := &passwordImpl{
+		cfg: Config{
+			MinLength:                  8,
+			MaxLength:                  20,
+			MaxNumOfConsecutiveChars:   2,
+			MinNumOfKindOfPasswordChar: 3,
+		},
+	}
+
+	pw, err := impl.New()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	b := pw.Password()
+	if len(b) != 8 {
+		t.Errorf("expected length 8, got %d", len(b))
+	}
+	if !impl.IsValid(pw) {
+		t.Error("generated password should be valid")
+	}
+}

--- a/signing/infrastructure/randombytesimpl/randombytesimpl_test.go
+++ b/signing/infrastructure/randombytesimpl/randombytesimpl_test.go
@@ -1,0 +1,46 @@
+package randombytesimpl
+
+import (
+	"testing"
+)
+
+func TestNewRandomBytesImpl(t *testing.T) {
+	impl := NewRandomBytesImpl()
+	if impl == nil {
+		t.Fatal("expected non-nil")
+	}
+}
+
+func TestNew(t *testing.T) {
+	impl := NewRandomBytesImpl()
+
+	b, err := impl.New(16)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(b) != 16 {
+		t.Errorf("expected 16 bytes, got %d", len(b))
+	}
+
+	b2, err := impl.New(32)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(b2) != 32 {
+		t.Errorf("expected 32 bytes, got %d", len(b2))
+	}
+
+	// Should produce different values
+	if len(b) == len(b2) {
+		same := true
+		for i := range b {
+			if b[i] != b2[i] {
+				same = false
+				break
+			}
+		}
+		if same {
+			t.Error("expected different random bytes")
+		}
+	}
+}

--- a/signing/infrastructure/randomcodeimpl/randomcodeimpl_test.go
+++ b/signing/infrastructure/randomcodeimpl/randomcodeimpl_test.go
@@ -1,0 +1,46 @@
+package randomcodeimpl
+
+import (
+	"testing"
+)
+
+func TestIsValid(t *testing.T) {
+	impl := NewRandomCodeImpl()
+
+	if !impl.IsValid("123456") {
+		t.Error("expected valid for '123456'")
+	}
+	if !impl.IsValid("000000") {
+		t.Error("expected valid for '000000'")
+	}
+	if !impl.IsValid("999999") {
+		t.Error("expected valid for '999999'")
+	}
+
+	if impl.IsValid("12345") {
+		t.Error("expected invalid for length 5")
+	}
+	if impl.IsValid("1234567") {
+		t.Error("expected invalid for length 7")
+	}
+	if impl.IsValid("abcdef") {
+		t.Error("expected invalid for letters")
+	}
+	if impl.IsValid("") {
+		t.Error("expected invalid for empty")
+	}
+	if impl.IsValid("1234 6") {
+		t.Error("expected invalid for space")
+	}
+}
+
+func TestNew(t *testing.T) {
+	impl := NewRandomCodeImpl()
+	code, err := impl.New()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !impl.IsValid(code) {
+		t.Errorf("generated code '%s' should be valid", code)
+	}
+}

--- a/signing/infrastructure/repositoryimpl/cache_test.go
+++ b/signing/infrastructure/repositoryimpl/cache_test.go
@@ -1,0 +1,62 @@
+package repositoryimpl
+
+import (
+	"testing"
+)
+
+func TestPageKey(t *testing.T) {
+	key := pageKey("link-1", 1, 20, false, "")
+	expected := corpSigningPageCachePrefix + "link-1:1:20:false:"
+	if key != expected {
+		t.Errorf("expected '%s', got '%s'", expected, key)
+	}
+
+	key2 := pageKey("link-2", 2, 10, true, "search-term")
+	expected2 := corpSigningPageCachePrefix + "link-2:2:10:true:search-term"
+	if key2 != expected2 {
+		t.Errorf("expected '%s', got '%s'", expected2, key2)
+	}
+}
+
+func TestLinkPattern(t *testing.T) {
+	pattern := linkPattern("link-1")
+	expected := corpSigningPageCachePrefix + "link-1:*"
+	if pattern != expected {
+		t.Errorf("expected '%s', got '%s'", expected, pattern)
+	}
+}
+
+func TestCorpSigningPageCacheConstants(t *testing.T) {
+	if corpSigningPageCachePrefix != "corp_signing:page:" {
+		t.Errorf("unexpected prefix: '%s'", corpSigningPageCachePrefix)
+	}
+	if corpSigningPageCacheTTL == 0 {
+		t.Error("expected non-zero TTL")
+	}
+}
+
+func TestCachedCorpSigningSummary(t *testing.T) {
+	s := cachedCorpSigningSummary{
+		Id:       "cs-1",
+		Date:     "2024-01-01",
+		HasPDF:   true,
+		LinkId:   "link-1",
+		CLAId:    "cla-1",
+		Language: "en",
+		RepName:  "CEO",
+		RepEmail: "ceo@t.com",
+	}
+	if s.Id != "cs-1" || s.HasPDF != true {
+		t.Errorf("cachedCorpSigningSummary mismatch")
+	}
+}
+
+func TestCachedCorpSigningPage(t *testing.T) {
+	page := cachedCorpSigningPage{
+		Total: 10,
+		Data:  []cachedCorpSigningSummary{{Id: "cs-1"}},
+	}
+	if page.Total != 10 || len(page.Data) != 1 {
+		t.Errorf("cachedCorpSigningPage mismatch")
+	}
+}

--- a/signing/infrastructure/repositoryimpl/do_test.go
+++ b/signing/infrastructure/repositoryimpl/do_test.go
@@ -1,0 +1,615 @@
+package repositoryimpl
+
+import (
+	"testing"
+
+	"github.com/opensourceways/app-cla-server/signing/domain"
+	"github.com/opensourceways/app-cla-server/signing/domain/dp"
+)
+
+func TestToLinkDOAndBack(t *testing.T) {
+	link := &domain.Link{
+		Id: "link-1",
+		Org: domain.OrgInfo{
+			Alias:      "TestOrg",
+			Logo:       "logo.png",
+			ProjectURL: "https://example.com",
+		},
+		Email: domain.EmailInfo{
+			Addr:     dp.CreateEmailAddr("org@test.com"),
+			Platform: "gmail",
+		},
+		Submitter: "admin",
+		CLANum:    1,
+		CLAs: []domain.CLA{
+			{
+				Id:       "0",
+				URL:      dp.CreateURL("https://example.com/cla.pdf"),
+				Type:     dp.CLATypeCorp,
+				Language: dp.CreateLanguage("en"),
+				Fields: []domain.Field{
+					{Id: "f0", Required: true, CLAField: dp.CLAField{Type: "text", Title: "Name", Desc: "desc"}},
+				},
+			},
+		},
+	}
+
+	do := toLinkDO(link)
+	if do.Id != "link-1" {
+		t.Errorf("expected 'link-1', got '%s'", do.Id)
+	}
+	if do.Org.Alias != "TestOrg" {
+		t.Errorf("expected 'TestOrg', got '%s'", do.Org.Alias)
+	}
+	if do.Email.Addr != "org@test.com" {
+		t.Errorf("expected 'org@test.com', got '%s'", do.Email.Addr)
+	}
+
+	result := do.toLink()
+	if result.Id != "link-1" || result.Org.Alias != "TestOrg" {
+		t.Errorf("roundtrip failed")
+	}
+}
+
+func TestToOrgInfoDOAndBack(t *testing.T) {
+	org := &domain.OrgInfo{Alias: "MyOrg", Logo: "logo.png", ProjectURL: "https://x.com"}
+	do := toOrgInfoDO(org)
+	result := do.toOrgInfo()
+	if result.Alias != "MyOrg" {
+		t.Errorf("expected 'MyOrg', got '%s'", result.Alias)
+	}
+}
+
+func TestToEmailInfoDOAndBack(t *testing.T) {
+	info := &domain.EmailInfo{Addr: dp.CreateEmailAddr("test@example.com"), Platform: "smtp"}
+	do := toEmailInfoDO(info)
+	if do.Platform != "smtp" {
+		t.Errorf("expected 'smtp', got '%s'", do.Platform)
+	}
+	result := do.toEmailInfo()
+	if result.Addr.EmailAddr() != "test@example.com" {
+		t.Errorf("expected 'test@example.com', got '%s'", result.Addr.EmailAddr())
+	}
+}
+
+func TestToFieldDOAndBack(t *testing.T) {
+	f := &domain.Field{Id: "f1", Required: true, CLAField: dp.CLAField{Type: "text", Title: "Name", Desc: "Desc"}}
+	do := toFieldDO(f)
+	if do.Id != "f1" || do.Type != "text" {
+		t.Errorf("toFieldDO mismatch")
+	}
+	result := do.toField()
+	if result.Id != "f1" || !result.Required {
+		t.Errorf("toField mismatch: %+v", result)
+	}
+}
+
+func TestToCLADOAndBack(t *testing.T) {
+	cla := &domain.CLA{
+		Id:       "0",
+		URL:      dp.CreateURL("https://x.com/a.pdf"),
+		Type:     dp.CLATypeCorp,
+		Language: dp.CreateLanguage("en"),
+		Fields: []domain.Field{
+			{Id: "f1", Required: true, CLAField: dp.CLAField{Type: "text", Title: "Name"}},
+		},
+	}
+	do := toCLADO(cla)
+	if do.Id != "0" || do.Type != "corporation" || do.URL != "https://x.com/a.pdf" {
+		t.Errorf("toCLADO mismatch")
+	}
+	result := do.toCLA()
+	if result.Id != "0" || result.Type.CLAType() != "corporation" {
+		t.Errorf("toCLA mismatch")
+	}
+}
+
+func TestClaContentDO(t *testing.T) {
+	do := claContentDO{
+		LinkId: "L1",
+		CLAId:  "C1",
+		Text:   []byte("content"),
+	}
+	if do.LinkId != "L1" || do.CLAId != "C1" {
+		t.Errorf("claContentDO mismatch")
+	}
+}
+
+func TestToRepDOAndBack(t *testing.T) {
+	rep := &domain.Representative{
+		Name:      dp.CreateName("John"),
+		EmailAddr: dp.CreateEmailAddr("john@test.com"),
+	}
+	do := toRepDO(rep)
+	if do.Name != "John" || do.Email != "john@test.com" {
+		t.Errorf("toRepDO mismatch")
+	}
+	result := do.toRep()
+	if result.Name.Name() != "John" {
+		t.Errorf("toRep mismatch")
+	}
+}
+
+func TestToRepDONil(t *testing.T) {
+	do := toRepDO(nil)
+	if do.Name != "" || do.Email != "" {
+		t.Errorf("expected empty RepDO for nil")
+	}
+
+	var nilRep *domain.Representative
+	do2 := toRepDO(nilRep)
+	if do2.Name != "" {
+		t.Errorf("expected empty for nil pointer")
+	}
+}
+
+func TestToCorpDOAndBack(t *testing.T) {
+	corp := &domain.Corporation{
+		Name:               dp.CreateCorpName("Acme"),
+		AllEmailDomains:    []string{"acme.com"},
+		PrimaryEmailDomain: "acme.com",
+	}
+	do := toCorpDO(corp)
+	if do.Name != "Acme" || do.Domain != "acme.com" {
+		t.Errorf("toCorpDO mismatch")
+	}
+	result := do.toCorp()
+	if result.Name.CorpName() != "Acme" {
+		t.Errorf("toCorp mismatch")
+	}
+}
+
+func TestToCorpDONil(t *testing.T) {
+	do := toCorpDO(nil)
+	if do.Name != "" || do.Domain != "" {
+		t.Errorf("expected empty for nil")
+	}
+}
+
+func TestIndividualSigningDO(t *testing.T) {
+	is := &domain.IndividualSigning{
+		Link: domain.LinkInfo{
+			Id: "link-1",
+			CLAInfo: domain.CLAInfo{
+				CLAId:    "cla-1",
+				Language: dp.CreateLanguage("en"),
+			},
+		},
+		Rep: domain.Representative{
+			Name:      dp.CreateName("Jane"),
+			EmailAddr: dp.CreateEmailAddr("jane@test.com"),
+		},
+		Date:    "2024-01-01",
+		AllInfo: domain.AllSingingInfo{"key": "val"},
+		Logs: []domain.IndividualSigningLog{
+			{Date: "2024-01-02", ClaId: "cla-2", Action: "update"},
+		},
+	}
+
+	do := toIndividualSigningDO(is)
+	if do.CLAId != "cla-1" || do.LinkId != "link-1" {
+		t.Errorf("toIndividualSigningDO mismatch: %+v", do)
+	}
+	if do.Language != "en" {
+		t.Errorf("expected 'en', got '%s'", do.Language)
+	}
+
+	result := do.toIndividualSigning()
+	if result.Link.Id != "link-1" || len(result.Logs) != 1 {
+		t.Errorf("toIndividualSigning mismatch: %+v", result)
+	}
+}
+
+func TestIndividualSigningLogDO(t *testing.T) {
+	log := domain.IndividualSigningLog{Date: "2024-01-01", ClaId: "cla-1", Action: "sign"}
+	do := toIndividualSigningLogDO(log)
+	if do.Date != "2024-01-01" {
+		t.Errorf("expected '2024-01-01', got '%s'", do.Date)
+	}
+	result := do.toIndividualSigningLog()
+	if result.ClaId != "cla-1" || result.Action != "sign" {
+		t.Errorf("roundtrip failed: %+v", result)
+	}
+}
+
+func TestToIndividualSigningLogsDO(t *testing.T) {
+	logs := []domain.IndividualSigningLog{
+		{Date: "d1", ClaId: "c1", Action: "a1"},
+		{Date: "d2", ClaId: "c2", Action: "a2"},
+	}
+	do := toIndividualSigningLogsDO(logs)
+	if len(do.Logs) != 2 {
+		t.Errorf("expected 2, got %d", len(do.Logs))
+	}
+}
+
+// --- Manager DO ---
+
+func TestToManagerDOAndBack(t *testing.T) {
+	m := &domain.Manager{
+		Id: "manager-1",
+		Representative: domain.Representative{
+			Name:      dp.CreateName("Bob"),
+			EmailAddr: dp.CreateEmailAddr("bob@test.com"),
+		},
+	}
+	do := toManagerDO(m)
+	if do.Id != "manager-1" || do.Name != "Bob" {
+		t.Errorf("toManagerDO mismatch: %+v", do)
+	}
+	result := do.toManager()
+	if result.Id != "manager-1" || result.Name.Name() != "Bob" {
+		t.Errorf("toManager mismatch: %+v", result)
+	}
+}
+
+func TestManagerDOIsEmpty(t *testing.T) {
+	empty := managerDO{}
+	if !empty.isEmpty() {
+		t.Error("expected isEmpty=true for zero value")
+	}
+	full := managerDO{Id: "m1"}
+	if full.isEmpty() {
+		t.Error("expected isEmpty=false for non-empty")
+	}
+}
+
+// --- Employee Signing DO ---
+
+func TestToEmployeeSigningDOAndBack(t *testing.T) {
+	es := &domain.EmployeeSigning{
+		Id: "es-1",
+		Rep: domain.Representative{
+			Name:      dp.CreateName("Alice"),
+			EmailAddr: dp.CreateEmailAddr("alice@test.com"),
+		},
+		CLA: domain.CLAInfo{
+			CLAId:    "cla-1",
+			Language: dp.CreateLanguage("en"),
+		},
+		Date:    "2024-01-01",
+		Enabled: true,
+		AllInfo: domain.AllSingingInfo{"k": "v"},
+		Logs: []domain.EmployeeSigningLog{
+			{Time: 100, Action: "sign"},
+			{Time: 200, Action: "update"},
+		},
+	}
+	do := toEmployeeSigningDO(es)
+	if do.Id != "es-1" || do.CLAId != "cla-1" || !do.Enabled {
+		t.Errorf("toEmployeeSigningDO mismatch: %+v", do)
+	}
+	result := do.toEmployeeSigning()
+	if result.Id != "es-1" || !result.Enabled || len(result.Logs) != 2 {
+		t.Errorf("toEmployeeSigning mismatch: %+v", result)
+	}
+}
+
+func TestToEmployeeSigningLogDOs(t *testing.T) {
+	logs := []domain.EmployeeSigningLog{
+		{Time: 100, Action: "sign"},
+		{Time: 200, Action: "update"},
+	}
+	dos := toEmployeeSigningLogDOs(logs)
+	if len(dos) != 2 {
+		t.Errorf("expected 2, got %d", len(dos))
+	}
+	if dos[0].Time != 100 || dos[0].Action != "sign" {
+		t.Errorf("log[0] mismatch")
+	}
+	r := dos[0].toEmployeeSigningLog()
+	if r.Time != 100 || r.Action != "sign" {
+		t.Errorf("roundtrip mismatch")
+	}
+}
+
+// --- Email Credential DO ---
+
+func TestToEmailCredentialDOAndBack(t *testing.T) {
+	e := &domain.EmailCredential{
+		Addr:     dp.CreateEmailAddr("test@example.com"),
+		Token:    []byte("secret"),
+		Platform: "gmail",
+	}
+	do := toEmailCredentialDO(e)
+	if do.Email != "test@example.com" || do.Platform != "gmail" {
+		t.Errorf("toEmailCredentialDO mismatch: %+v", do)
+	}
+	result := do.toEmailCredential()
+	if result.Addr.EmailAddr() != "test@example.com" || result.Platform != "gmail" {
+		t.Errorf("toEmailCredential mismatch: %+v", result)
+	}
+}
+
+// --- CorpSigning DO (more) ---
+
+func TestToCorpSigningDO(t *testing.T) {
+	cs := &domain.CorpSigning{
+		Id:   "cs-1",
+		Date: "2024-06-01",
+		Link: domain.LinkInfo{
+			Id: "link-1",
+			CLAInfo: domain.CLAInfo{
+				CLAId:    "cla-1",
+				Language: dp.CreateLanguage("en"),
+			},
+		},
+		Rep: domain.Representative{
+			Name:      dp.CreateName("CEO"),
+			EmailAddr: dp.CreateEmailAddr("ceo@corp.com"),
+		},
+		Corp: domain.Corporation{
+			Name:               dp.CreateCorpName("BigCorp"),
+			AllEmailDomains:    []string{"bigcorp.com"},
+			PrimaryEmailDomain: "bigcorp.com",
+		},
+		AllInfo: domain.AllSingingInfo{"field": "value"},
+		Admin: domain.Manager{
+			Id: "admin-1",
+			Representative: domain.Representative{
+				Name:      dp.CreateName("Admin"),
+				EmailAddr: dp.CreateEmailAddr("admin@bigcorp.com"),
+			},
+		},
+		Managers: []domain.Manager{
+			{
+				Id: "mgr-1",
+				Representative: domain.Representative{
+					Name:      dp.CreateName("Mgr1"),
+					EmailAddr: dp.CreateEmailAddr("mgr1@bigcorp.com"),
+				},
+			},
+		},
+	}
+
+	do := toCorpSigningDO(cs)
+	if do.CLAId != "cla-1" || do.LinkId != "link-1" || do.Language != "en" {
+		t.Errorf("toCorpSigningDO mismatch: %+v", do)
+	}
+	if do.Rep.Name != "CEO" || do.Rep.Email != "ceo@corp.com" {
+		t.Errorf("rep mismatch: %+v", do.Rep)
+	}
+
+	summary := do.toCorpSigningSummary()
+	if summary.Id != do.index() {
+		t.Errorf("expected '%s', got '%s'", do.index(), summary.Id)
+	}
+	if summary.Date != "2024-06-01" {
+		t.Errorf("date mismatch")
+	}
+
+	result := do.toCorpSigning()
+	if result.Id != do.index() || result.Link.Id != "link-1" {
+		t.Errorf("toCorpSigning mismatch")
+	}
+}
+
+func TestToCorpSigningDOForMigrate(t *testing.T) {
+	cs := &domain.CorpSigning{
+		Id:   "cs-mig",
+		Date: "2024-01-01",
+		Link: domain.LinkInfo{
+			Id: "link-1",
+			CLAInfo: domain.CLAInfo{
+				CLAId:    "cla-1",
+				Language: dp.CreateLanguage("en"),
+			},
+		},
+		Rep: domain.Representative{
+			Name:      dp.CreateName("CEO"),
+			EmailAddr: dp.CreateEmailAddr("ceo@test.com"),
+		},
+		Corp: domain.Corporation{
+			Name:               dp.CreateCorpName("Corp"),
+			AllEmailDomains:    []string{"corp.com"},
+			PrimaryEmailDomain: "corp.com",
+		},
+		Admin: domain.Manager{
+			Id: "admin",
+			Representative: domain.Representative{
+				Name:      dp.CreateName("Admin"),
+				EmailAddr: dp.CreateEmailAddr("admin@corp.com"),
+			},
+		},
+	}
+
+	do := toCorpSigningDOForMigrate(cs)
+	if do.Admin.Name != "Admin" {
+		t.Errorf("expected admin name 'Admin', got '%s'", do.Admin.Name)
+	}
+	if len(do.Managers) > 0 {
+		t.Errorf("expected 0 managers, got %d", len(do.Managers))
+	}
+}
+
+func TestAllManagers(t *testing.T) {
+	do := &corpSigningDO{
+		Admin: managerDO{
+			Id: "admin",
+			RepDO: RepDO{
+				Name:  "Admin",
+				Email: "admin@test.com",
+			},
+		},
+		Managers: []managerDO{
+			{Id: "mgr-1", RepDO: RepDO{Name: "Mgr1", Email: "mgr1@test.com"}},
+		},
+	}
+
+	managers := do.allManagers()
+	if len(managers) != 2 {
+		t.Errorf("expected 2, got %d", len(managers))
+	}
+}
+
+func TestToEmployeeSigningDOs(t *testing.T) {
+	employees := []domain.EmployeeSigning{
+		{
+			Id: "es-1",
+			Rep: domain.Representative{
+				Name:      dp.CreateName("E1"),
+				EmailAddr: dp.CreateEmailAddr("e1@test.com"),
+			},
+			CLA: domain.CLAInfo{CLAId: "cla-1", Language: dp.CreateLanguage("en")},
+		},
+	}
+	dos := toEmployeeSigningDOs(employees)
+	if len(dos) != 1 {
+		t.Errorf("expected 1, got %d", len(dos))
+	}
+	if dos[0].Id != "es-1" {
+		t.Errorf("expected 'es-1', got '%s'", dos[0].Id)
+	}
+
+	// Test nil
+	nilDos := toEmployeeSigningDOs(nil)
+	if nilDos != nil {
+		t.Error("expected nil for nil input")
+	}
+}
+
+func TestToManagerDOs(t *testing.T) {
+	managers := []domain.Manager{
+		{
+			Id: "m1",
+			Representative: domain.Representative{
+				Name:      dp.CreateName("M1"),
+				EmailAddr: dp.CreateEmailAddr("m1@test.com"),
+			},
+		},
+	}
+	dos := toManagerDOs(managers)
+	if len(dos) != 1 || dos[0].Id != "m1" {
+		t.Errorf("toManagerDOs mismatch")
+	}
+
+	// Test nil
+	nilDos := toManagerDOs(nil)
+	if nilDos != nil {
+		t.Error("expected nil for nil input")
+	}
+}
+
+func TestToManagers(t *testing.T) {
+	do := &corpSigningDO{
+		Managers: []managerDO{
+			{Id: "m1", RepDO: RepDO{Name: "M1", Email: "m1@test.com"}},
+		},
+	}
+	ms := do.toManagers()
+	if len(ms) != 1 || ms[0].Id != "m1" {
+		t.Errorf("toManagers mismatch")
+	}
+}
+
+func TestToEmployeeSignings(t *testing.T) {
+	do := &corpSigningDO{
+		Employees: []employeeSigningDO{
+			{Id: "es-1", CLAId: "cla-1"},
+		},
+	}
+	ess := do.toEmployeeSignings()
+	if len(ess) != 1 || ess[0].Id != "es-1" {
+		t.Errorf("toEmployeeSignings mismatch")
+	}
+}
+
+func TestConstValues(t *testing.T) {
+	// Ensure important constants are defined
+	if fieldPDF == "" || fieldRep == "" || fieldId == "" {
+		t.Error("expected constant definitions")
+	}
+}
+
+func TestToUserDO(t *testing.T) {
+	u := &domain.User{
+		LinkId:        "link-1",
+		CorpSigningId: "cs-1",
+		UserBasicInfo: domain.UserBasicInfo{
+			Id:              "user-1",
+			Account:         dp.CreateAccount("user001"),
+			Password:        []byte("enc"),
+			EmailAddr:       dp.CreateEmailAddr("user@test.com"),
+			PasswordChanged: true,
+			PrivacyConsent:  domain.PrivacyConsent{Time: "2024-01-01", Version: "v1"},
+			Version:         1,
+		},
+	}
+	do := toUserDO(u)
+	if do.Email != "user@test.com" || do.Account != "user001" || do.LinkId != "link-1" {
+		t.Errorf("toUserDO mismatch: %+v", do)
+	}
+
+	result := do.toUser()
+	if result.LinkId != "link-1" || result.UserBasicInfo.Id == "" || result.Account.Account() != "user001" {
+		t.Errorf("toUser mismatch: %+v", result)
+	}
+}
+
+func TestToUserDOForMigrate(t *testing.T) {
+	u := &domain.User{
+		LinkId:        "link-1",
+		CorpSigningId: "cs-1",
+		UserBasicInfo: domain.UserBasicInfo{
+			EmailAddr:      dp.CreateEmailAddr("user@test.com"),
+			Account:        dp.CreateAccount("user001"),
+			PrivacyConsent: domain.PrivacyConsent{Time: "2024-01-01", Version: "v2"},
+		},
+	}
+	do := toUserDOForMigrate(u)
+	if do.Email != "user@test.com" || do.PrivacyConsent.Version != "v2" {
+		t.Errorf("toUserDOForMigrate mismatch: %+v", do)
+	}
+
+	// nil test
+	nilDo := toUserDOForMigrate(nil)
+	if nilDo.Email != "" {
+		t.Errorf("expected empty for nil")
+	}
+}
+
+func TestToPrivacyConsentDO(t *testing.T) {
+	p := domain.PrivacyConsent{Time: "2024-01-01", Version: "v1"}
+	do := toPrivacyConsentDO(p)
+	if do.Time != "2024-01-01" || do.Version != "v1" {
+		t.Errorf("toPrivacyConsentDO mismatch: %+v", do)
+	}
+}
+
+func TestToVerificationCodeDOAndBack(t *testing.T) {
+	purpose, _ := dp.NewPurpose("test-purpose")
+	vc := &domain.VerificationCode{
+		Expiry: 100,
+		VerificationCodeKey: domain.VerificationCodeKey{
+			Code:    "123456",
+			Purpose: purpose,
+		},
+	}
+	do := toVerificationCodeDO(vc)
+	if do.Code != "123456" || do.Expiry != 100 || do.Purpose != "test-purpose" {
+		t.Errorf("toVerificationCodeDO mismatch: %+v", do)
+	}
+	result := do.toVerificationCode()
+	if result.Code != "123456" || result.Expiry != 100 {
+		t.Errorf("toVerificationCode mismatch: %+v", result)
+	}
+}
+
+func TestToVerificationCodeFilter(t *testing.T) {
+	purpose, _ := dp.NewPurpose("signing-purpose")
+	key := &domain.VerificationCodeKey{
+		Code:    "654321",
+		Purpose: purpose,
+	}
+	filter := toVerificationCodeFilter(key)
+	if filter[fieldCode] != "654321" || filter[fieldPurpose] != "signing-purpose" {
+		t.Errorf("filter mismatch: %+v", filter)
+	}
+}
+
+func TestPrivacyConsentDO(t *testing.T) {
+	do := privacyConsentDO{Time: "2024-01-01", Version: "v1"}
+	if do.Time != "2024-01-01" {
+		t.Errorf("privacyConsentDO mismatch")
+	}
+}

--- a/signing/infrastructure/repositoryimpl/mongodb_test.go
+++ b/signing/infrastructure/repositoryimpl/mongodb_test.go
@@ -1,0 +1,70 @@
+package repositoryimpl
+
+import (
+	"testing"
+)
+
+func TestGenDoc(t *testing.T) {
+	type testStruct struct {
+		Name  string `json:"name"`
+		Value int    `json:"value"`
+	}
+	doc := testStruct{Name: "test", Value: 42}
+	result, err := genDoc(doc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result["name"] != "test" {
+		t.Errorf("expected 'test', got '%v'", result["name"])
+	}
+	if v, ok := result["value"].(float64); !ok || int(v) != 42 {
+		t.Errorf("expected 42, got %v", result["value"])
+	}
+}
+
+func TestLinkIdFilter(t *testing.T) {
+	filter := linkIdFilter("link-1")
+	if filter[fieldLinkId] != "link-1" {
+		t.Errorf("expected 'link-1', got '%v'", filter[fieldLinkId])
+	}
+}
+
+func TestChildField(t *testing.T) {
+	result := childField("a", "b", "c")
+	if result != "a.b.c" {
+		t.Errorf("expected 'a.b.c', got '%s'", result)
+	}
+
+	result = childField("single")
+	if result != "single" {
+		t.Errorf("expected 'single', got '%s'", result)
+	}
+}
+
+func TestMongodbConstants(t *testing.T) {
+	if mongodbCmdOr != "$or" || mongodbCmdIn != "$in" {
+		t.Error("constant mismatch")
+	}
+	if mongodbCmdLt != "$lt" || mongodbCmdElemMatch != "$elemMatch" {
+		t.Error("constant mismatch")
+	}
+}
+
+func TestConfigStruct(t *testing.T) {
+	cfg := Config{
+		Collections: Collections{
+			Org:               "org",
+			CLA:               "cla",
+			Link:              "link",
+			User:              "user",
+			PrivacyConsent:    "privacy",
+			CorpSigning:       "corp_signing",
+			EmailCredential:   "email_credential",
+			VerificationCode:  "verification_code",
+			IndividualSigning: "individual_signing",
+		},
+	}
+	if cfg.Collections.Org != "org" || cfg.Collections.IndividualSigning != "individual_signing" {
+		t.Errorf("config mismatch")
+	}
+}

--- a/signing/infrastructure/smtpimpl/smtpimpl_test.go
+++ b/signing/infrastructure/smtpimpl/smtpimpl_test.go
@@ -1,0 +1,115 @@
+package smtpimpl
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestConfigSetDefault(t *testing.T) {
+	cfg := &Config{}
+	cfg.SetDefault()
+	if cfg.Port != 465 {
+		t.Errorf("expected 465, got %d", cfg.Port)
+	}
+	if cfg.Host != "smtp.exmail.qq.com" {
+		t.Errorf("expected 'smtp.exmail.qq.com', got '%s'", cfg.Host)
+	}
+	if cfg.Platform != "smtp" {
+		t.Errorf("expected 'smtp', got '%s'", cfg.Platform)
+	}
+}
+
+func TestConfigSetDefaultKeepsCustom(t *testing.T) {
+	cfg := &Config{
+		Port:     587,
+		Host:     "smtp.gmail.com",
+		Platform: "gmail",
+	}
+	cfg.SetDefault()
+	if cfg.Port != 587 {
+		t.Errorf("expected 587, got %d", cfg.Port)
+	}
+	if cfg.Host != "smtp.gmail.com" {
+		t.Errorf("expected 'smtp.gmail.com', got '%s'", cfg.Host)
+	}
+}
+
+func TestSimpleTxmailMessage(t *testing.T) {
+	var buf bytes.Buffer
+	buf.WriteString("This is the email body")
+
+	msg := &EmailMessage{
+		From:    "sender@test.com",
+		To:      []string{"receiver@test.com"},
+		Subject: "Test Subject",
+		Content: buf,
+		MIME:    "",
+	}
+
+	m := simpleTxmailMessage(msg)
+	if m == nil {
+		t.Fatal("expected non-nil message")
+	}
+}
+
+func TestSimpleTxmailMessageWithMIME(t *testing.T) {
+	var buf bytes.Buffer
+	buf.WriteString("HTML body")
+
+	msg := &EmailMessage{
+		From:    "sender@test.com",
+		To:      []string{"receiver@test.com"},
+		Subject: "HTML Email",
+		Content: buf,
+		MIME:    "Content-Type: text/html",
+	}
+
+	m := simpleTxmailMessage(msg)
+	if m == nil {
+		t.Fatal("expected non-nil message")
+	}
+}
+
+func TestCreateTxMailMessageWithoutAttachment(t *testing.T) {
+	impl := &smtpImpl{cfg: Config{Port: 587, Host: "smtp.test.com"}}
+
+	var buf bytes.Buffer
+	buf.WriteString("body")
+	msg := &EmailMessage{
+		From:       "from@test.com",
+		To:         []string{"to@test.com"},
+		Subject:    "Test",
+		Content:    buf,
+		Attachment: "",
+	}
+
+	m, err := impl.createTxMailMessage(msg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m == nil {
+		t.Fatal("expected non-nil")
+	}
+}
+
+func TestCreateTxMailMessageWithAttachment(t *testing.T) {
+	impl := &smtpImpl{cfg: Config{Port: 587, Host: "smtp.test.com"}}
+
+	var buf bytes.Buffer
+	buf.WriteString("body with attachment")
+	msg := &EmailMessage{
+		From:       "from@test.com",
+		To:         []string{"to@test.com"},
+		Subject:    "Test with file",
+		Content:    buf,
+		Attachment: "/tmp/fake-file.pdf",
+	}
+
+	m, err := impl.createTxMailMessage(msg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m == nil {
+		t.Fatal("expected non-nil")
+	}
+}

--- a/signing/infrastructure/symmetricencryptionimpl/symmetricencryptionimpl_test.go
+++ b/signing/infrastructure/symmetricencryptionimpl/symmetricencryptionimpl_test.go
@@ -1,0 +1,61 @@
+package symmetricencryptionimpl
+
+import (
+	"testing"
+)
+
+func TestNewSymmetricEncryptionImpl(t *testing.T) {
+	// AES-128 key must be 16 bytes
+	cfg := &Config{EncryptionKey: "1234567890123456"}
+	impl, err := NewSymmetricEncryptionImpl(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if impl == nil {
+		t.Fatal("expected non-nil")
+	}
+}
+
+func TestNewSymmetricEncryptionImplInvalidKey(t *testing.T) {
+	cfg := &Config{EncryptionKey: "short"}
+	_, err := NewSymmetricEncryptionImpl(cfg)
+	if err == nil {
+		t.Error("expected error for short key")
+	}
+}
+
+func TestSymmetricEncryptDecrypt(t *testing.T) {
+	cfg := &Config{EncryptionKey: "1234567890123456"}
+	impl, err := NewSymmetricEncryptionImpl(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	plaintext := []byte("hello world")
+	ciphertext, err := impl.Encrypt(plaintext)
+	if err != nil {
+		t.Fatalf("encrypt error: %v", err)
+	}
+
+	decrypted, err := impl.Decrypt(ciphertext)
+	if err != nil {
+		t.Fatalf("decrypt error: %v", err)
+	}
+
+	if string(decrypted) != string(plaintext) {
+		t.Errorf("expected '%s', got '%s'", plaintext, decrypted)
+	}
+}
+
+func TestDecryptTooShort(t *testing.T) {
+	cfg := &Config{EncryptionKey: "1234567890123456"}
+	impl, err := NewSymmetricEncryptionImpl(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	_, err = impl.Decrypt([]byte("short"))
+	if err == nil {
+		t.Error("expected error for short ciphertext")
+	}
+}

--- a/signing/watch/config_test.go
+++ b/signing/watch/config_test.go
@@ -1,0 +1,71 @@
+package watch
+
+import (
+	"testing"
+	"time"
+)
+
+func TestConfigSetDefault(t *testing.T) {
+	cfg := &Config{}
+	cfg.SetDefault()
+	if cfg.Interval != 3600 {
+		t.Errorf("expected 3600, got %d", cfg.Interval)
+	}
+	if cfg.intervalDuration() != 3600*time.Second {
+		t.Errorf("expected 1h, got %v", cfg.intervalDuration())
+	}
+}
+
+func TestConfigSetDefaultKeepsCustom(t *testing.T) {
+	cfg := &Config{Interval: 7200}
+	cfg.SetDefault()
+	if cfg.Interval != 7200 {
+		t.Errorf("expected 7200, got %d", cfg.Interval)
+	}
+}
+
+func TestCLAUpdateConfigSetDefault(t *testing.T) {
+	cfg := &CLAUpdateConfig{}
+	cfg.SetDefault()
+	if cfg.MsgChannelSize != 100 {
+		t.Errorf("expected 100, got %d", cfg.MsgChannelSize)
+	}
+	if cfg.PythonRetryTimes != 3 {
+		t.Errorf("expected 3, got %d", cfg.PythonRetryTimes)
+	}
+	if cfg.GenAllDiffInterval != 600 {
+		t.Errorf("expected 600, got %d", cfg.GenAllDiffInterval)
+	}
+	if cfg.genAllDiffInterval() != 600*time.Second {
+		t.Errorf("expected 10m, got %v", cfg.genAllDiffInterval())
+	}
+}
+
+func TestNotifyAdminConfigSetDefault(t *testing.T) {
+	cfg := &NotifyAdminConfig{}
+	cfg.SetDefault()
+	if cfg.SendEmailInterval != 10 {
+		t.Errorf("expected 10, got %d", cfg.SendEmailInterval)
+	}
+	if cfg.NotifyCorpAdminInterval != 1200 {
+		t.Errorf("expected 1200, got %d", cfg.NotifyCorpAdminInterval)
+	}
+}
+
+func TestNotifyAdminConfigIntervals(t *testing.T) {
+	cfg := &NotifyAdminConfig{SendEmailInterval: 20, NotifyCorpAdminInterval: 2400}
+	if cfg.genSendEmailInterval() != 20*time.Second {
+		t.Errorf("expected 20s, got %v", cfg.genSendEmailInterval())
+	}
+	if cfg.genNotifyCorpAdminInterval() != 2400*time.Second {
+		t.Errorf("expected 2400s, got %v", cfg.genNotifyCorpAdminInterval())
+	}
+}
+
+func TestConfigConfigItems(t *testing.T) {
+	cfg := &Config{}
+	items := cfg.ConfigItems()
+	if len(items) != 2 {
+		t.Errorf("expected 2, got %d", len(items))
+	}
+}

--- a/util/multi_error_test.go
+++ b/util/multi_error_test.go
@@ -1,0 +1,79 @@
+package util
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestMultiErrors(t *testing.T) {
+	err := MultiErrors()
+	if err != nil {
+		t.Errorf("expected nil, got: %v", err)
+	}
+
+	err = MultiErrors(nil, nil)
+	if err != nil {
+		t.Errorf("expected nil, got: %v", err)
+	}
+
+	err = MultiErrors(errors.New("err1"), errors.New("err2"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if err.Error() != "err1. err2" {
+		t.Errorf("expected 'err1. err2', got '%s'", err.Error())
+	}
+
+	err = MultiErrors(errors.New("only one"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if err.Error() != "only one" {
+		t.Errorf("expected 'only one', got '%s'", err.Error())
+	}
+}
+
+func TestNewMultiError(t *testing.T) {
+	m := NewMultiError()
+	if err := m.Err(); err != nil {
+		t.Errorf("expected nil, got: %v", err)
+	}
+}
+
+func TestMultiErrorAdd(t *testing.T) {
+	m := NewMultiError()
+	m.Add("error one")
+	m.Add("error two")
+
+	err := m.Err()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if err.Error() != "error one. error two" {
+		t.Errorf("expected 'error one. error two', got '%s'", err.Error())
+	}
+}
+
+func TestMultiErrorAddError(t *testing.T) {
+	m := NewMultiError()
+	m.AddError(errors.New("err1"))
+	m.AddError(errors.New("err2"))
+	m.AddError(nil) // should be ignored
+
+	err := m.Err()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if err.Error() != "err1. err2" {
+		t.Errorf("expected 'err1. err2', got '%s'", err.Error())
+	}
+}
+
+func TestMultiErrorNil(t *testing.T) {
+	var m *MultiError
+	m.Add("test")   // should not panic
+	m.AddError(errors.New("test")) // should not panic
+	if err := m.Err(); err != nil {
+		t.Errorf("expected nil for nil MultiError, got: %v", err)
+	}
+}

--- a/util/time_test.go
+++ b/util/time_test.go
@@ -1,0 +1,49 @@
+package util
+
+import (
+	"testing"
+)
+
+func TestDate(t *testing.T) {
+	d := Date()
+	if len(d) != 10 {
+		t.Errorf("expected YYYY-MM-DD format, got '%s'", d)
+	}
+}
+
+func TestTime(t *testing.T) {
+	tm := Time()
+	if len(tm) != 19 {
+		t.Errorf("expected YYYY-MM-DD HH:MM:SS format, got '%s'", tm)
+	}
+}
+
+func TestNow(t *testing.T) {
+	n := Now()
+	if n <= 0 {
+		t.Errorf("expected positive timestamp, got %d", n)
+	}
+}
+
+func TestExpiry(t *testing.T) {
+	n := Now()
+	e := Expiry(10) // 10 seconds
+	if e <= n {
+		t.Errorf("expected expiry > now, got expiry=%d now=%d", e, n)
+	}
+}
+
+func TestCheckContentType(t *testing.T) {
+	if !CheckContentType([]byte("<html>"), "text/html") {
+		t.Error("expected true for HTML content type")
+	}
+	if CheckContentType([]byte("<html>"), "image/png") {
+		t.Error("expected false for mismatched content type")
+	}
+
+	// plain text detection
+	data := []byte("hello world")
+	if !CheckContentType(data, "text/plain") {
+		t.Error("expected true for plain text content")
+	}
+}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,0 +1,85 @@
+package util
+
+import (
+	"testing"
+)
+
+func TestHasXSS(t *testing.T) {
+	if !HasXSS("<script>") {
+		t.Error("expected true for XSS content '<script>'")
+	}
+	if !HasXSS("a&b") {
+		t.Error("expected true for XSS content 'a&b'")
+	}
+	if !HasXSS(`"quote"`) {
+		t.Error("expected true for XSS content with double quote")
+	}
+	if !HasXSS("a'b") {
+		t.Error("expected true for XSS content with single quote")
+	}
+	if !HasXSS("a/b") {
+		t.Error("expected true for XSS content with slash")
+	}
+	if HasXSS("hello world") {
+		t.Error("expected false for normal text")
+	}
+	if HasXSS("a-b_c.123") {
+		t.Error("expected false for safe characters")
+	}
+}
+
+func TestCheckEmail(t *testing.T) {
+	if err := CheckEmail("test@example.com"); err != nil {
+		t.Errorf("expected valid, got: %v", err)
+	}
+	if err := CheckEmail("user+tag@example.co.uk"); err != nil {
+		t.Errorf("expected valid, got: %v", err)
+	}
+	if err := CheckEmail("a@b.cd"); err != nil {
+		t.Errorf("expected valid, got: %v", err)
+	}
+
+	if err := CheckEmail(""); err == nil {
+		t.Error("expected invalid for empty email")
+	}
+	if err := CheckEmail("not-an-email"); err == nil {
+		t.Error("expected invalid for 'not-an-email'")
+	}
+	if err := CheckEmail("@missing-user.com"); err == nil {
+		t.Error("expected invalid for '@missing-user.com'")
+	}
+}
+
+func TestStrLen(t *testing.T) {
+	if n := StrLen("hello"); n != 5 {
+		t.Errorf("expected 5, got %d", n)
+	}
+	if n := StrLen("你好世界"); n != 4 {
+		t.Errorf("expected 4, got %d", n)
+	}
+	if n := StrLen(""); n != 0 {
+		t.Errorf("expected 0, got %d", n)
+	}
+}
+
+func TestEmailSuffix(t *testing.T) {
+	if s := EmailSuffix("user@example.com"); s != "example.com" {
+		t.Errorf("expected 'example.com', got '%s'", s)
+	}
+	if s := EmailSuffix("a@b.c"); s != "b.c" {
+		t.Errorf("expected 'b.c', got '%s'", s)
+	}
+	if s := EmailSuffix("no-at-sign"); s != "no-at-sign" {
+		t.Errorf("expected 'no-at-sign', got '%s'", s)
+	}
+	if s := EmailSuffix(""); s != "" {
+		t.Errorf("expected '', got '%s'", s)
+	}
+}
+
+func TestGenFilePath(t *testing.T) {
+	p := GenFilePath("/tmp", "file.txt")
+	if p != "/tmp/file.txt" {
+		t.Errorf("expected '/tmp/file.txt', got '%s'", p)
+	}
+}


### PR DESCRIPTION
## 描述
- 修复 8 个 stdlib CVE 漏洞 (CVE-2026-33811, CVE-2026-33814, CVE-2026-39820, CVE-2026-39823, CVE-2026-39825, CVE-2026-39826, CVE-2026-39836, CVE-2026-42499)
- 将 Go 版本从 1.25.9 升级到 1.25.10
- 新增单元测试，保证通过门禁
## 相关 Issue

resolve https://github.com/opensourceways/backlog/issues/323

## 变更类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 代码重构
- [ ] 文档更新
- [ ] 样式改进
- [ ] 性能优化
- [ ] 测试相关
- [ ] 其他
