### PR TITLE
CLA 协议变更平滑过渡机制 — 非阻塞式版本检查 + 宽限期-的开发实现-app-cla-server部分

### DIFF
--- a/controllers/individual_signing.go
+++ b/controllers/individual_signing.go
@@ -141,9 +141,8 @@ func (ctl *IndividualSigningController) Check() {
 		ctl.GetString(":link_id"), ctl.GetString("email"),
 	)
 
-	// 非 debug 模式时隐藏调试信息
+	// status 是权威状态字段，始终返回；调试信息仅在 debug 模式下返回
 	if !debug {
-		v.Status = ""
 		v.DebugInfo = nil
 	}
 

--- a/models/individual_signing.go
+++ b/models/individual_signing.go
@@ -29,7 +29,7 @@ type IndividualSigningInfo struct {
 type IndividualSigned struct {
 	Type           string     `json:"type"`                      // "individual" 或 "corp"
 	Signed         bool       `json:"signed"`                    // 是否已签署过
-	VersionMatched bool       `json:"version_matched,omitempty"` // 签署是否当前有效（考虑宽限期）
+	VersionMatched bool       `json:"version_matched"`            // 签署是否当前有效（考虑宽限期），始终返回以兼容旧版本调用
 	Status         string     `json:"status"`                    // 内部状态："not_signed" | "valid" | "expired"
 	DebugInfo      *DebugInfo `json:"_debug,omitempty"`          // 调试信息（仅debug=true时返回）
 }

--- a/models/individual_signing_test.go
+++ b/models/individual_signing_test.go
@@ -1,0 +1,125 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestIndividualSignedJSONSerialization verifies that the Check API response
+// always includes signed, version_matched and status fields so that legacy
+// callers keep working and the new authoritative status field is always present.
+//
+// Requirement (#909): the response must look like
+//
+//	{"data":{"type":"corporation","signed":true,"version_matched":true,"status":"valid"}}
+//
+// for all three states (not_signed / valid / expired), signed and
+// version_matched must be present even when false.
+func TestIndividualSignedJSONSerialization(t *testing.T) {
+	tests := []struct {
+		name string
+		in   IndividualSigned
+		want map[string]interface{}
+	}{
+		{
+			name: "valid",
+			in: IndividualSigned{
+				Type:           "corporation",
+				Signed:         true,
+				VersionMatched: true,
+				Status:         "valid",
+			},
+			want: map[string]interface{}{
+				"type":            "corporation",
+				"signed":          true,
+				"version_matched": true,
+				"status":          "valid",
+			},
+		},
+		{
+			name: "expired keeps version_matched:false",
+			in: IndividualSigned{
+				Type:           "corporation",
+				Signed:         true,
+				VersionMatched: false,
+				Status:         "expired",
+			},
+			want: map[string]interface{}{
+				"type":            "corporation",
+				"signed":          true,
+				"version_matched": false,
+				"status":          "expired",
+			},
+		},
+		{
+			name: "not_signed keeps signed:false and version_matched:false",
+			in: IndividualSigned{
+				Type:           "individual",
+				Signed:         false,
+				VersionMatched: false,
+				Status:         "not_signed",
+			},
+			want: map[string]interface{}{
+				"type":            "individual",
+				"signed":          false,
+				"version_matched": false,
+				"status":          "not_signed",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, err := json.Marshal(tt.in)
+			if err != nil {
+				t.Fatalf("json.Marshal returned unexpected error: %v", err)
+			}
+
+			var got map[string]interface{}
+			if err := json.Unmarshal(raw, &got); err != nil {
+				t.Fatalf("json.Unmarshal returned unexpected error: %v", err)
+			}
+
+			for k, wantVal := range tt.want {
+				gotVal, ok := got[k]
+				if !ok {
+					t.Errorf("missing field %q in response: %s", k, string(raw))
+					continue
+				}
+				if gotVal != wantVal {
+					t.Errorf("field %q = %v (%T), want %v (%T)",
+						k, gotVal, gotVal, wantVal, wantVal)
+				}
+			}
+
+			if _, ok := got["_debug"]; ok {
+				t.Errorf("_debug should be omitted when DebugInfo is nil, got: %s", string(raw))
+			}
+		})
+	}
+}
+
+// TestIndividualSignedDebugInfoOmittedWhenNil ensures the debug payload is
+// only exposed when populated (i.e. debug=true).
+func TestIndividualSignedDebugInfoOmittedWhenNil(t *testing.T) {
+	in := IndividualSigned{
+		Type:           "individual",
+		Signed:         true,
+		VersionMatched: true,
+		Status:         "valid",
+	}
+
+	raw, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("json.Marshal returned unexpected error: %v", err)
+	}
+
+	var got map[string]interface{}
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("json.Unmarshal returned unexpected error: %v", err)
+	}
+
+	if _, ok := got["_debug"]; ok {
+		t.Errorf("_debug must be omitted when nil, got: %s", string(raw))
+	}
+}


### PR DESCRIPTION
## 背景

CLA 协议变更平滑过渡机制 — 非阻塞式版本检查 + 宽限期（app-cla-server）· 开发流水线 · 开发预览阶段（代码已推 + 预览已部署 + UT 已补；门禁/对抗由 PR CI 异步跑）

## 改动内容

fix(app-cla-server): 修复签署状态查询接口 status/version_matched 字段未始终返回的问题

## 改动说明

issue #909 触发评论中用户（@JavaPythonAIForBAT）明确要求 `/api/v1/individual-signing/{cla_id}?email=...` 接口返回的数据必须形如：
`{"data":{"type":"corporation","signed":true,"version_matched":true,"status":"valid"}}`
其中 `status` 是新增的权威状态字段（取值 not_signed/valid/expired），且 `signed`、`version_matched` 必须始终返回以兼容旧版本调用。

经核查已有实现（review 分支），发现两处与该要求直接冲突的 bug：

### 1. controllers/individual_signing.go —— 非	debug 模式下 status 被清空
原实现在 `Check()` 中有：
```go
if !debug {
    v.Status = ""      // ❌ 把权威状态字段当成调试信息清掉了
    v.DebugInfo = nil
}
```
`Status` 不是调试信息，而是用户要求始终返回的权威字段。生产调用（不带 debug 参数）会得到 `"status":""`，与要求的 `not_signed/valid/expired` 不符。

修复：移除 `v.Status = ""`，仅保留 `v.DebugInfo = nil`（真正属于 debug 的内容）。注释同步更新为「status 是权威状态字段，始终返回；调试信息仅在 debug 模式下返回」。

### 2. models/individual_signing.go —— version_matched 带 omitempty 导致 false 被省略
`IndividualSigned.VersionMatched` 的 json tag 为 `version_matched,omitempty`。需求分析说明书验收标准 #2 明确给出三种返回样例：
- 未签署：`version_matched:false`
- 有效：`version_matched:true`
- 过期：`version_matched:false`

带 `omitempty` 时，not_signed / expired 两种情况下 `version_matched:false` 会被 JSON 编码器省略，破坏向后兼容（旧版本调用方读不到该字段）。上一个 commit `4315576` 只去掉了 `signed`、`status` 的 omitempty，遗漏了 `version_matched`。

修复：移除 `VersionMatched` 的 `omitempty`，与 `Signed`、`Status` 保持一致，确保三态下 `version_matched` 始终出现在响应里。

## 涉及文件
- `controllers/individual_signing.go`（Check：不再清空 status）
- `models/individual_signing.go`（IndividualSigned.VersionMatched 去 omitempty）

## 单元测试
新增 `models/individual_signing_test.go`：
- `TestIndividualSignedJSONSerialization`：表驱动覆盖 valid / expired / not_signed 三种状态，断言 `type`、`signed`、`version_matched`、`status` 四字段在 JSON 响应中均存在且取值正确（重点验证 false 值不被 omitempty 吞掉）。
- `TestIndividualSignedDebugInfoOmittedWhenNil`：验证 DebugInfo 为 nil 时 `_debug` 被省略（即非 debug 模式不泄露调试信息）。

已用「先回退 fix 再跑测试」的方式确认该测试能精准捕捉上述 bug（回退后 expired/not_signed 两个用例因 `version_matched` 缺失而 FAIL，恢复后全绿）。

## 验证
- `go build ./...` 通过
- `go vet ./models/ ./controllers/` 通过
- `go test ./...` 全部包 PASS（models / signing/domain / signing/domain/randomcode / signing/domain/vcservice / signing/watch）

## 相关 Issue

resolve https://github.com/opensourceways/backlog/issues/909

## AI 使用声明

当前 PR 是否有 AI 参与：

- [ ] 否
- [x] 是
  1. AI Agent 平台：opencode（Workflow Develop · 需求实现）
  2. AI 模型：bigmodel/glm-5.2
  3. Prompt 上下文：https://github.com/opensourceways/backlog/issues/909 的 `/ai-develop-preview`
