### PR TITLE
fix: AgreeNewCLA 使用签署记录中的语言而非前端传入的 CLAId

### DIFF
--- a/signing/app/individual_signing.go
+++ b/signing/app/individual_signing.go
@@ -86,16 +86,17 @@ func (s *individualSigningService) AgreeNewCLA(cmd *CmdToSignIndividualCLA) erro
 		return err
 	}
 
-	if !s.cla.ContainsCla(cmd.Link.Id, cmd.Link.CLAId) {
-		return domain.NewDomainError(domain.ErrorCodeCLANotExists)
-	}
-
 	sign, err := s.repo.Find(cmd.Link.Id, cmd.Rep.EmailAddr)
 	if err != nil {
 		return err
 	}
 
-	if err = sign.AgreeNewCLA(cmd.Link.CLAId); err != nil {
+	latestClaId := s.cla.GetClaId(sign.Link.Id, dp.CLATypeIndividual, sign.Link.Language)
+	if latestClaId == "" {
+		return domain.NewDomainError(domain.ErrorCodeCLANotExists)
+	}
+
+	if err = sign.AgreeNewCLA(latestClaId); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Summary
- 修复个人签署者同意新 CLA 时，语言/CLAId 错误的问题

## 问题
用户原签署英文版 CLA，前端默认显示中文版，若点"同意"会错误地将英文签署改为中文版签署。

## 修复
`AgreeNewCLA` 不再信任前端传入的 `cmd.Link.CLAId`，改为从签署记录 `sign.Link.Language` 获取用户原始签署语言，查询该语言对应的最新 CLA id 来确认同意。

## 改动
1 file: `signing/app/individual_signing.go`