### PR TITLE
fix: TriggerNotify 按 CLA 类型触发，不再同时触发企业和个人两边

### DIFF
--- a/signing/app/cla.go
+++ b/signing/app/cla.go
@@ -62,11 +62,13 @@ func (s *claService) Update(cmd *CmdToUpdateCLA) error {
 		return err
 	}
 
-	if err = s.cs.SetPendingCLAForLink(cmd.LinkId, cla.Id); err != nil {
-		logs.Error("set pending CLA for link failed: %s, err: %v", cmd.LinkId, err)
+	if !dp.IsCLATypeIndividual(cla.Type) {
+		if err = s.cs.SetPendingCLAForLink(cmd.LinkId, cla.Id); err != nil {
+			logs.Error("set pending CLA for link failed: %s, err: %v", cmd.LinkId, err)
+		}
 	}
 
-	watch.TriggerNotify()
+	watch.TriggerNotify(cla.Type)
 
 	return nil
 }

--- a/signing/watch/notify_corp_admin.go
+++ b/signing/watch/notify_corp_admin.go
@@ -42,18 +42,22 @@ func NotifyAdminWatchStop() {
 }
 
 // TriggerNotify 立即触发一次通知扫描，不等待定时器周期。
-// CLA 更新后应调用此函数，确保企业和个人都在最短时间内收到通知。
-func TriggerNotify() {
+// t 指定要触发的 CLA 类型，只触发对应类型的扫描器。
+func TriggerNotify(t dp.CLAType) {
 	if notifyAdminWatchInstance == nil {
 		return
 	}
-	select {
-	case notifyAdminWatchInstance.corpTrigger <- struct{}{}:
-	default:
+	if !dp.IsCLATypeIndividual(t) {
+		select {
+		case notifyAdminWatchInstance.corpTrigger <- struct{}{}:
+		default:
+		}
 	}
-	select {
-	case notifyAdminWatchInstance.individualTrigger <- struct{}{}:
-	default:
+	if dp.IsCLATypeIndividual(t) {
+		select {
+		case notifyAdminWatchInstance.individualTrigger <- struct{}{}:
+		default:
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- 个人 CLA 更新时不再标记企业签署为待通知，也不再触发企业扫描
- 企业 CLA 更新时只触发企业扫描，不触发个人扫描

## 问题
TriggerNotify() 无条件同时触发企业和个人两个扫描器，更新个人 CLA 时也给所有企业发邮件。

## 修复
- TriggerNotify(t) 加类型参数，按需触发
- Update 中 SetPendingCLAForLink 仅企业 CLA 更新时标记

## 改动
2 files: signing/app/cla.go, signing/watch/notify_corp_admin.go