### PR TITLE
fix: 删除 CLA 更新后的立即通知，统一走定时器扫描

### DIFF
--- a/conf/email-template/cla-updated.tmpl
+++ b/conf/email-template/cla-updated.tmpl
@@ -2,7 +2,7 @@ Dear {{.AdminName}},
 
 A new version of CLA is published. Please login to the CLA management system to see the details.
 
-The CLA management system login URL is {{.URLOfCLAPlatform}}.
+The CLA management system login URL is {{.URLOfCLAPlatform}}
 
 Have questions or need help? Just reply to this email and the {{.Org}} Community Support Team will help you sort it out.
 

--- a/signing/app/cla.go
+++ b/signing/app/cla.go
@@ -7,7 +7,6 @@ import (
 	"github.com/opensourceways/app-cla-server/signing/domain/claservice"
 	"github.com/opensourceways/app-cla-server/signing/domain/dp"
 	"github.com/opensourceways/app-cla-server/signing/domain/repository"
-	"github.com/opensourceways/app-cla-server/signing/watch"
 )
 
 func NewCLAService(
@@ -65,8 +64,6 @@ func (s *claService) Update(cmd *CmdToUpdateCLA) error {
 	if err = s.cs.SetPendingCLAForLink(cmd.LinkId, cla.Id); err != nil {
 		logs.Error("set pending CLA for link failed: %s, err: %v", cmd.LinkId, err)
 	}
-
-	watch.TriggerNotify()
 
 	return nil
 }

--- a/signing/watch/notify_corp_admin.go
+++ b/signing/watch/notify_corp_admin.go
@@ -26,8 +26,6 @@ func NotifyAdminWatchStart(cfg *NotifyAdminConfig, lk repoLink, corp corpSigning
 		claPlatformURL:         claPlatformURL,
 		defaultGracePeriodDays: defaultGracePeriodDays,
 		stop:                   make(chan struct{}),
-		corpTrigger:            make(chan struct{}, 1),
-		individualTrigger:      make(chan struct{}, 1),
 	}
 
 	notifyAdminWatchInstance.start()
@@ -38,22 +36,6 @@ func NotifyAdminWatchStop() {
 		notifyAdminWatchInstance.exit()
 
 		logs.Info("stop watching send email")
-	}
-}
-
-// TriggerNotify 立即触发一次通知扫描，不等待定时器周期。
-// CLA 更新后应调用此函数，确保企业和个人都在最短时间内收到通知。
-func TriggerNotify() {
-	if notifyAdminWatchInstance == nil {
-		return
-	}
-	select {
-	case notifyAdminWatchInstance.corpTrigger <- struct{}{}:
-	default:
-	}
-	select {
-	case notifyAdminWatchInstance.individualTrigger <- struct{}{}:
-	default:
 	}
 }
 
@@ -77,10 +59,8 @@ type notifyAdminWatchImpl struct {
 
 	defaultGracePeriodDays int
 
-	wg                sync.WaitGroup
-	stop              chan struct{}
-	corpTrigger       chan struct{}
-	individualTrigger chan struct{}
+	wg   sync.WaitGroup
+	stop chan struct{}
 }
 
 func (impl *notifyAdminWatchImpl) start() {
@@ -107,9 +87,6 @@ func (impl *notifyAdminWatchImpl) notifyCorpAdmin() {
 			impl.wg.Done()
 			return
 		case <-timer.C:
-			impl.handleNotifyJob()
-			timer.Reset(impl.nextDelay(interval))
-		case <-impl.corpTrigger:
 			impl.handleNotifyJob()
 			timer.Reset(impl.nextDelay(interval))
 		}
@@ -270,9 +247,6 @@ func (impl *notifyAdminWatchImpl) notifyIndividualSigner() {
 			impl.wg.Done()
 			return
 		case <-timer.C:
-			impl.handleIndividualNotifyJob()
-			timer.Reset(impl.nextDelay(interval))
-		case <-impl.individualTrigger:
 			impl.handleIndividualNotifyJob()
 			timer.Reset(impl.nextDelay(interval))
 		}


### PR DESCRIPTION
## Summary
- 删除 CLA 更新后的立即通知触发（TriggerNotify）
- SetPendingCLAForLink 保留，持久化通知标记
- 通知统一走定时器（12:00 + 0:00）扫描

## 原因
大社区场景下立即触发受 batch_size=500 限制只能发 500 封，剩余仍需等定时器，立即无实际意义。删除后统一走定时器，逻辑更简单可靠。