### PR TITLE
fix: 调整链接展示形式，防止最后的句号导致链接无法直接跳转

### DIFF
--- a/conf/email-template/adding-corp-admin.tmpl
+++ b/conf/email-template/adding-corp-admin.tmpl
@@ -6,7 +6,8 @@ Account Detail:
   Username: {{.Email}} or {{.ID}}
   Password: {{printf "%s" .Password}}
 
-The CLA management system login URL is {{.URLOfCLAPlatform}}.
+The CLA management system login URL:
+  {{.URLOfCLAPlatform}}
 
 Have questions or need help? Just reply to this email and the {{.Org}} Community Support Team will help you sort it out.
 

--- a/conf/email-template/adding-corp-manager.tmpl
+++ b/conf/email-template/adding-corp-manager.tmpl
@@ -6,7 +6,8 @@ Your Account:
   Username: {{.Email}}{{if .ID}} or {{.ID}}{{end}}
   Password: {{printf "%s" .Password}}
 
-The CLA management system login URL is {{.URLOfCLAPlatform}}.
+The CLA management system login URL:
+  {{.URLOfCLAPlatform}}
 
 Have questions or need help? Just reply to this email and the {{.Org}} Community Support Team will help you sort it out.
 

--- a/conf/email-template/cla-updated.tmpl
+++ b/conf/email-template/cla-updated.tmpl
@@ -2,7 +2,8 @@ Dear {{.AdminName}},
 
 A new version of CLA is published. Please login to the CLA management system to see the details.
 
-The CLA management system login URL is {{.URLOfCLAPlatform}}.
+The CLA management system login URL:
+  {{.URLOfCLAPlatform}}
 
 Have questions or need help? Just reply to this email and the {{.Org}} Community Support Team will help you sort it out.
 

--- a/conf/email-template/notifying-corp-manager.tmpl
+++ b/conf/email-template/notifying-corp-manager.tmpl
@@ -2,7 +2,8 @@ Dear manager,
 
 An employee whose email is {{.EmployeeEmail}} of your company has just signed the CLA to the project[1] of "{{.Org}}". Please login to the CLA management system in time to activate the employee's contribution privileges.
 
-The CLA management system login URL is {{.URLOfCLAPlatform}}.
+The CLA management system login URL:
+  {{.URLOfCLAPlatform}}
 
 Have questions or need help? Just reply to this email and the {{.Org}} Community Support Team will help you sort it out.
 


### PR DESCRIPTION
## 修改内容
增加协议变更的收件人替换的配置

## Issue
resolve https://github.com/opensourceways/backlog/pull/909