### PR TITLE
fix: 调整链接展示形式，防止最后的句号导致链接无法直接跳转

### DIFF
--- a/conf/email-template/cla-updated-individual.tmpl
+++ b/conf/email-template/cla-updated-individual.tmpl
@@ -1,6 +1,6 @@
 Dear {{.Name}},
 
-The Contributor License Agreement (CLA) of the {{.Org}} community has been updated on {{.UpdateDate}}.
+The Contributor License Agreement (CLA) of the {{.Org}}[1] community has been updated on {{.UpdateDate}}.
 
 You have previously signed the CLA, and you can still contribute code normally — the smooth transition mechanism ensures no disruption to your daily development workflow.
 
@@ -10,6 +10,6 @@ Within {{.GracePeriodDays}} days after the update, you would still match the lat
 Please agree to the latest agreement version by clicking the link below:
   Sign CLA URL: {{.SignCLAURL}}
 
-Have questions or need help? Just reply to this email and the {{.Org}} Community Support Team will help you sort it out.
+Have questions or need help? Just reply to this email and the {{.Org}}[1] Community Support Team will help you sort it out.
 
 [1]. {{.ProjectURL}}

--- a/conf/email-template/cla-updated.tmpl
+++ b/conf/email-template/cla-updated.tmpl
@@ -5,6 +5,6 @@ A new version of CLA is published. Please login to the CLA management system to 
 The CLA management system login URL:
   {{.URLOfCLAPlatform}}
 
-Have questions or need help? Just reply to this email and the {{.Org}} Community Support Team will help you sort it out.
+Have questions or need help? Just reply to this email and the {{.Org}}[1] Community Support Team will help you sort it out.
 
 [1]. {{.ProjectURL}}


### PR DESCRIPTION
## 修改内容
增加协议变更的收件人替换的配置

## Issue
resolve https://github.com/opensourceways/backlog/pull/909