### PR TITLE
fix: 调整链接展示形式，防止最后的句号导致链接无法直接跳转

### DIFF
--- a/conf/email-template/cla-updated-individual.tmpl
+++ b/conf/email-template/cla-updated-individual.tmpl
@@ -12,4 +12,5 @@ Please agree to the latest agreement version by clicking the link below:
 
 Have questions or need help? Just reply to this email and the {{.Org}} Community Support Team will help you sort it out.
 
-{{.ProjectURL}}
+Address of the {{.Org}} Project:
+  {{.ProjectURL}}

--- a/conf/email-template/cla-updated.tmpl
+++ b/conf/email-template/cla-updated.tmpl
@@ -7,4 +7,5 @@ The CLA management system login URL:
 
 Have questions or need help? Just reply to this email and the {{.Org}} Community Support Team will help you sort it out.
 
-{{.ProjectURL}}
+Address of the {{.Org}} Project:
+  {{.ProjectURL}}


### PR DESCRIPTION
## 修改内容
增加协议变更的收件人替换的配置

## Issue
resolve https://github.com/opensourceways/backlog/pull/909