### PR TITLE
[需求] CLA企业签署之后，需要自动将员工以个人签署的相关CLA自动归集到企业中-的开发实现-app-cla-server部分

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,6 @@
+# gitleaks:ignore -- false positives / historical findings reviewed below
+#
+# Historical test fixture token (fake value a1b2c3d4e5f6a7b8 in a _test.go
+# assertion URL). The line no longer exists in the working tree; it only
+# remains in git history at the commit below. Not a real credential.
+a1916610f002ba855d7f99b1ffb5d45ea66baf5b:signing/watch/notify_corp_admin_test.go:generic-api-key:288

--- a/models/individual_signing.go
+++ b/models/individual_signing.go
@@ -16,6 +16,7 @@ type IndividualSigningBasicInfo struct {
 	Name    string `json:"name"`
 	Date    string `json:"date"`
 	Enabled bool   `json:"enabled"`
+	Source  string `json:"source,omitempty"` // "individual" = collected from individual signing
 }
 
 type IndividualSigningInfo struct {

--- a/models/individual_signing_test.go
+++ b/models/individual_signing_test.go
@@ -6,15 +6,15 @@ import (
 )
 
 // TestIndividualSignedJSONSerialization verifies that the Check API response
-// always includes signed, version_matched and status fields so that legacy
-// callers keep working and the new authoritative status field is always present.
+// always includes signed and version_matched fields so that legacy callers
+// keep working.
 //
-// Requirement (#909): the response must look like
+// The signing states are fully covered by the two fields (refactor b8e3107):
 //
-//	{"data":{"type":"corporation","signed":true,"version_matched":true,"status":"valid"}}
+//	{"data":{"type":"corporation","signed":true,"version_matched":true}}
 //
-// for all three states (not_signed / valid / expired), signed and
-// version_matched must be present even when false.
+// signed and version_matched must be present even when false, for all three
+// states (not_signed / valid / expired).
 func TestIndividualSignedJSONSerialization(t *testing.T) {
 	tests := []struct {
 		name string
@@ -27,13 +27,11 @@ func TestIndividualSignedJSONSerialization(t *testing.T) {
 				Type:           "corporation",
 				Signed:         true,
 				VersionMatched: true,
-				Status:         "valid",
 			},
 			want: map[string]interface{}{
 				"type":            "corporation",
 				"signed":          true,
 				"version_matched": true,
-				"status":          "valid",
 			},
 		},
 		{
@@ -42,13 +40,11 @@ func TestIndividualSignedJSONSerialization(t *testing.T) {
 				Type:           "corporation",
 				Signed:         true,
 				VersionMatched: false,
-				Status:         "expired",
 			},
 			want: map[string]interface{}{
 				"type":            "corporation",
 				"signed":          true,
 				"version_matched": false,
-				"status":          "expired",
 			},
 		},
 		{
@@ -57,13 +53,11 @@ func TestIndividualSignedJSONSerialization(t *testing.T) {
 				Type:           "individual",
 				Signed:         false,
 				VersionMatched: false,
-				Status:         "not_signed",
 			},
 			want: map[string]interface{}{
 				"type":            "individual",
 				"signed":          false,
 				"version_matched": false,
-				"status":          "not_signed",
 			},
 		},
 	}
@@ -106,7 +100,6 @@ func TestIndividualSignedDebugInfoOmittedWhenNil(t *testing.T) {
 		Type:           "individual",
 		Signed:         true,
 		VersionMatched: true,
-		Status:         "valid",
 	}
 
 	raw, err := json.Marshal(in)

--- a/signing.go
+++ b/signing.go
@@ -48,6 +48,13 @@ func initSigning(cfg *config.Config) error {
 		return err
 	}
 
+	if err := mongodb.EnsureIndexes(
+		cfg.Mongodb.Collections.IndividualSigning,
+		repositoryimpl.IndividualSigningIndexes(),
+	); err != nil {
+		return err
+	}
+
 	repo := repositoryimpl.NewCachedCorpSigning(
 		mongodb.DAO(cfg.Mongodb.Collections.CorpSigning),
 		redisdb.DAO(),

--- a/signing/adapter/employee_signing.go
+++ b/signing/adapter/employee_signing.go
@@ -124,6 +124,7 @@ func (adapter *employeeSigningAdatper) List(csId string) (
 			Email:   item.Email,
 			Date:    item.Date,
 			Enabled: item.Enabled,
+			Source:  item.Source,
 		}
 	}
 

--- a/signing/app/employee_signing.go
+++ b/signing/app/employee_signing.go
@@ -145,5 +145,6 @@ func (s *employeeSigningService) toEmployeeSigningDTO(v *domain.EmployeeSigning)
 	return EmployeeSigningDTO{
 		IndividualSigningDTO: dto,
 		Enabled:              v.Enabled,
+		Source:               v.Source,
 	}
 }

--- a/signing/app/employee_signing_dto.go
+++ b/signing/app/employee_signing_dto.go
@@ -52,5 +52,6 @@ type IndividualSigningDTO struct {
 type EmployeeSigningDTO struct {
 	IndividualSigningDTO
 
-	Enabled bool `json:"enabled"`
+	Enabled bool   `json:"enabled"`
+	Source  string `json:"source,omitempty"`
 }

--- a/signing/domain/corp_signing.go
+++ b/signing/domain/corp_signing.go
@@ -181,6 +181,26 @@ func (cs *CorpSigning) AddEmployee(es *EmployeeSigning) error {
 	return nil
 }
 
+// CollectEmployee appends an employee signing collected from a historical
+// individual signing. Unlike AddEmployee, it does not require managers to be
+// configured: the corp pdf can be uploaded before any manager exists, and
+// the collected record stays disabled until a manager activates it.
+func (cs *CorpSigning) CollectEmployee(es *EmployeeSigning) error {
+	if !cs.isSameCorpIgnoreCase(es.Rep.EmailAddr) {
+		return NewDomainError(ErrorCodeEmployeeNotSameCorp)
+	}
+
+	for i := range cs.Employees {
+		if cs.Employees[i].isMe(es) {
+			return NewDomainError(ErrorCodeEmployeeSigningReSigning)
+		}
+	}
+
+	cs.Employees = append(cs.Employees, *es)
+
+	return nil
+}
+
 func (cs *CorpSigning) UpdateEmployee(index string, enabled bool) (es *EmployeeSigning, err error) {
 	i, ok := cs.posOfEmployee(index)
 	if !ok {
@@ -217,6 +237,10 @@ func (cs *CorpSigning) RemoveEmployee(index string) (es *EmployeeSigning, err er
 
 func (cs *CorpSigning) isSameCorp(email dp.EmailAddr) bool {
 	return cs.Corp.isMyEmail(email)
+}
+
+func (cs *CorpSigning) isSameCorpIgnoreCase(email dp.EmailAddr) bool {
+	return cs.Corp.isMyEmailIgnoreCase(email)
 }
 
 func (cs *CorpSigning) hasManager(m *Manager) bool {

--- a/signing/domain/corporation.go
+++ b/signing/domain/corporation.go
@@ -1,6 +1,8 @@
 package domain
 
 import (
+	"strings"
+
 	"github.com/opensourceways/app-cla-server/signing/domain/dp"
 )
 
@@ -23,6 +25,18 @@ func (c *Corporation) isMyEmail(email dp.EmailAddr) bool {
 
 	for _, v := range c.AllEmailDomains {
 		if v == domain {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (c *Corporation) isMyEmailIgnoreCase(email dp.EmailAddr) bool {
+	domain := email.Domain()
+
+	for _, v := range c.AllEmailDomains {
+		if strings.EqualFold(v, domain) {
 			return true
 		}
 	}

--- a/signing/domain/employee_signing.go
+++ b/signing/domain/employee_signing.go
@@ -8,7 +8,12 @@ const (
 	employeeSigningActionEnable  = "enable"
 	employeeSigningActionDisable = "disable"
 	employeeSigningActionDelete  = "delete"
+	employeeSigningActionCollect = "collect"
 )
+
+// EmployeeSigningSourceIndividual marks the employee signing is collected
+// from a historical individual signing.
+const EmployeeSigningSourceIndividual = "individual"
 
 type EmployeeSigningLog struct {
 	Time   int64
@@ -23,6 +28,27 @@ type EmployeeSigning struct {
 	Enabled bool
 	AllInfo AllSingingInfo
 	Logs    []EmployeeSigningLog
+	Source  string
+}
+
+// NewCollectedEmployeeSigning generates a disabled employee signing from a
+// historical individual signing. It must be activated by a corp manager
+// before it takes effect.
+func NewCollectedEmployeeSigning(
+	cla CLAInfo, rep Representative, date string, all AllSingingInfo,
+) EmployeeSigning {
+	es := EmployeeSigning{
+		CLA:     cla,
+		Rep:     rep,
+		Date:    date,
+		Enabled: false,
+		AllInfo: all,
+		Source:  EmployeeSigningSourceIndividual,
+	}
+
+	es.addLog(employeeSigningActionCollect)
+
+	return es
 }
 
 func (es *EmployeeSigning) isMe(es1 *EmployeeSigning) bool {

--- a/signing/domain/employee_signing_collect_test.go
+++ b/signing/domain/employee_signing_collect_test.go
@@ -1,0 +1,136 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/opensourceways/app-cla-server/signing/domain/dp"
+)
+
+func TestNewCollectedEmployeeSigning(t *testing.T) {
+	cla := CLAInfo{CLAId: "cla1", Language: dp.CreateLanguage("en")}
+	rep := Representative{
+		Name:      dp.CreateName("stu"),
+		EmailAddr: dp.CreateEmailAddr("stu@uni.edu.cn"),
+	}
+	all := AllSingingInfo{"name": "stu"}
+
+	es := NewCollectedEmployeeSigning(cla, rep, "2026-01-01", all)
+
+	if es.Enabled {
+		t.Error("collected employee signing must be disabled")
+	}
+	if es.Source != EmployeeSigningSourceIndividual {
+		t.Errorf("Source = %q, want %q", es.Source, EmployeeSigningSourceIndividual)
+	}
+	if es.CLA != cla {
+		t.Errorf("CLA = %v, want %v", es.CLA, cla)
+	}
+	if es.Rep.EmailAddr.EmailAddr() != "stu@uni.edu.cn" {
+		t.Errorf("email = %s", es.Rep.EmailAddr.EmailAddr())
+	}
+	if es.Date != "2026-01-01" {
+		t.Errorf("Date = %s, want the original individual signing date", es.Date)
+	}
+	if len(es.Logs) != 1 || es.Logs[0].Action != "collect" {
+		t.Errorf("Logs = %v, want one collect entry", es.Logs)
+	}
+	if es.Logs[0].Time <= 0 {
+		t.Errorf("collect log time = %d, want a unix timestamp", es.Logs[0].Time)
+	}
+}
+
+func TestCorpSigningCollectEmployee(t *testing.T) {
+	newCorp := func(domains ...string) *CorpSigning {
+		return &CorpSigning{
+			Corp: Corporation{
+				AllEmailDomains:    domains,
+				PrimaryEmailDomain: domains[0],
+			},
+		}
+	}
+
+	t.Run("success without managers", func(t *testing.T) {
+		cs := newCorp("uni.edu.cn")
+
+		es := NewCollectedEmployeeSigning(
+			CLAInfo{CLAId: "cla1"},
+			Representative{EmailAddr: dp.CreateEmailAddr("stu@uni.edu.cn")},
+			"2026-01-01", nil,
+		)
+
+		if err := cs.CollectEmployee(&es); err != nil {
+			t.Fatalf("CollectEmployee: unexpected error %v", err)
+		}
+		if len(cs.Employees) != 1 {
+			t.Fatalf("employees = %d, want 1", len(cs.Employees))
+		}
+		if !cs.Employees[0].isMe(&es) {
+			t.Error("the collected employee signing should be appended")
+		}
+	})
+
+	t.Run("rejects email of other corp", func(t *testing.T) {
+		cs := newCorp("uni.edu.cn")
+
+		es := NewCollectedEmployeeSigning(
+			CLAInfo{CLAId: "cla1"},
+			Representative{EmailAddr: dp.CreateEmailAddr("stu@other.com")},
+			"2026-01-01", nil,
+		)
+
+		if err := cs.CollectEmployee(&es); err == nil {
+			t.Error("CollectEmployee should fail for an email outside the corp domains")
+		}
+		if len(cs.Employees) != 0 {
+			t.Errorf("employees = %d, want 0", len(cs.Employees))
+		}
+	})
+
+	t.Run("rejects duplicated employee", func(t *testing.T) {
+		cs := newCorp("uni.edu.cn")
+		cs.Employees = []EmployeeSigning{
+			{Id: "e1", Rep: Representative{EmailAddr: dp.CreateEmailAddr("stu@uni.edu.cn")}},
+		}
+
+		es := NewCollectedEmployeeSigning(
+			CLAInfo{CLAId: "cla1"},
+			Representative{EmailAddr: dp.CreateEmailAddr("stu@uni.edu.cn")},
+			"2026-01-01", nil,
+		)
+
+		if err := cs.CollectEmployee(&es); err == nil {
+			t.Error("CollectEmployee should fail for a duplicated email")
+		}
+		if len(cs.Employees) != 1 {
+			t.Errorf("employees = %d, want 1", len(cs.Employees))
+		}
+	})
+
+	t.Run("domain matching is case insensitive", func(t *testing.T) {
+		cs := newCorp("UNI.edu.cn")
+
+		es := NewCollectedEmployeeSigning(
+			CLAInfo{CLAId: "cla1"},
+			Representative{EmailAddr: dp.CreateEmailAddr("stu@uni.edu.cn")},
+			"2026-01-01", nil,
+		)
+
+		if err := cs.CollectEmployee(&es); err != nil {
+			t.Fatalf("CollectEmployee: unexpected error %v", err)
+		}
+	})
+}
+
+func TestCorporationIsMyEmailIgnoreCase(t *testing.T) {
+	corp := Corporation{AllEmailDomains: []string{"UNI.edu.cn", "Other.com"}}
+
+	if !corp.isMyEmailIgnoreCase(dp.CreateEmailAddr("user@uni.edu.cn")) {
+		t.Error("should match ignoring case")
+	}
+	if !corp.isMyEmailIgnoreCase(dp.CreateEmailAddr("user@OTHER.com")) {
+		t.Error("should match ignoring case")
+	}
+	if corp.isMyEmailIgnoreCase(dp.CreateEmailAddr("user@unknown.com")) {
+		t.Error("should not match unknown domain")
+	}
+}

--- a/signing/domain/repository/individual_signing.go
+++ b/signing/domain/repository/individual_signing.go
@@ -10,6 +10,7 @@ type IndividualSigning interface {
 	AddForMigrate(*domain.IndividualSigning) error
 	FindSignedCLA(linkId string, email dp.EmailAddr) (claId string, language dp.Language, err error)
 	Find(linkId string, email dp.EmailAddr) (domain.IndividualSigning, error)
+	FindByDomains(linkId string, domains []string) ([]domain.IndividualSigning, error)
 	FindAll(LinkId string) ([]domain.IndividualSigning, error)
 	FindAllWithPagination(linkId string, offset, limit int) ([]domain.IndividualSigning, error)
 	CountByLinkId(linkId string) (int64, error)

--- a/signing/infrastructure/repositoryimpl/collect_test.go
+++ b/signing/infrastructure/repositoryimpl/collect_test.go
@@ -1,0 +1,188 @@
+package repositoryimpl
+
+import (
+	"errors"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+
+	"github.com/opensourceways/app-cla-server/signing/domain"
+	"github.com/opensourceways/app-cla-server/signing/domain/dp"
+)
+
+func TestEmployeeSigningDOCollectedSource(t *testing.T) {
+	rep := domain.Representative{
+		Name:      dp.CreateName("stu"),
+		EmailAddr: dp.CreateEmailAddr("stu@uni.edu.cn"),
+	}
+
+	t.Run("source is kept by the round trip", func(t *testing.T) {
+		es := domain.NewCollectedEmployeeSigning(
+			domain.CLAInfo{CLAId: "cla1", Language: dp.CreateLanguage("en")},
+			rep, "2026-01-01", domain.AllSingingInfo{"name": "stu"},
+		)
+
+		do := toEmployeeSigningDO(&es)
+
+		if do.Source != domain.EmployeeSigningSourceIndividual {
+			t.Errorf("DO source = %q, want %q", do.Source, domain.EmployeeSigningSourceIndividual)
+		}
+
+		back := do.toEmployeeSigning()
+
+		if back.Source != domain.EmployeeSigningSourceIndividual {
+			t.Errorf("domain source = %q, want %q", back.Source, domain.EmployeeSigningSourceIndividual)
+		}
+		if back.Enabled {
+			t.Error("collected employee signing should stay disabled")
+		}
+		if len(back.Logs) != 1 || back.Logs[0].Action != "collect" {
+			t.Errorf("logs = %v, want one collect entry", back.Logs)
+		}
+	})
+
+	t.Run("source is omitted when empty", func(t *testing.T) {
+		es := domain.EmployeeSigning{
+			Id:   "e1",
+			CLA:  domain.CLAInfo{CLAId: "cla1", Language: dp.CreateLanguage("en")},
+			Rep:  rep,
+			Date: "2026-01-01",
+		}
+
+		do := toEmployeeSigningDO(&es)
+		doc, err := do.toDoc()
+		if err != nil {
+			t.Fatalf("toDoc: unexpected error %v", err)
+		}
+
+		if _, ok := doc["source"]; ok {
+			t.Errorf("source should be omitted for self-signed employee signing, got %v", doc["source"])
+		}
+	})
+}
+
+func TestToDomainRegexConditions(t *testing.T) {
+	got := toDomainRegexConditions([]string{"uni.edu.cn", "a+b.cn", "x.*y.org"})
+
+	if len(got) != 3 {
+		t.Fatalf("conditions = %d, want 3", len(got))
+	}
+
+	expect := []string{`(?i)^uni\.edu\.cn$`, `(?i)^a\+b\.cn$`, `(?i)^x\.\*y\.org$`}
+
+	for i := range expect {
+		c, ok := got[i].(bson.M)
+		if !ok {
+			t.Fatalf("condition %d is %T, want bson.M", i, got[i])
+		}
+		if c["$regex"] != expect[i] {
+			t.Errorf("condition %d regex = %q, want %q", i, c["$regex"], expect[i])
+		}
+	}
+}
+
+func TestIndividualSigningIndexes(t *testing.T) {
+	indexes := IndividualSigningIndexes()
+
+	if len(indexes) != 1 {
+		t.Fatalf("indexes = %d, want 1", len(indexes))
+	}
+
+	keys, ok := indexes[0].Keys.(bson.D)
+	if !ok {
+		t.Fatalf("index keys type = %T, want bson.D", indexes[0].Keys)
+	}
+	if len(keys) != 2 {
+		t.Fatalf("index keys = %d, want 2", len(keys))
+	}
+	if keys[0].Key != fieldLinkId || keys[1].Key != fieldDomain {
+		t.Errorf("index keys = %v, want link_id+domain", keys)
+	}
+}
+
+// fakeDAO implements dao by embedding the interface, only the methods used
+// by the tests are overridden.
+type fakeDAO struct {
+	dao
+
+	getDocsFn func(filter, project bson.M, result interface{}) error
+}
+
+func (f *fakeDAO) GetDocs(filter, project bson.M, result interface{}) error {
+	return f.getDocsFn(filter, project, result)
+}
+
+func TestIndividualSigningFindByDomains(t *testing.T) {
+	t.Run("no domains", func(t *testing.T) {
+		impl := NewIndividualSigning(&fakeDAO{})
+
+		v, err := impl.FindByDomains("link1", nil)
+		if err != nil || v != nil {
+			t.Errorf("got (%v, %v), want (nil, nil)", v, err)
+		}
+	})
+
+	t.Run("builds the expected filter and converts the docs", func(t *testing.T) {
+		var gotFilter bson.M
+
+		impl := NewIndividualSigning(&fakeDAO{
+			getDocsFn: func(filter, project bson.M, result interface{}) error {
+				gotFilter = filter
+
+				dos, ok := result.(*[]individualSigningDO)
+				if !ok {
+					t.Fatalf("result type = %T, want *[]individualSigningDO", result)
+				}
+
+				*dos = []individualSigningDO{{
+					LinkId: "link1",
+					Date:   "2026-01-01",
+					Domain: "uni.edu.cn",
+				}}
+
+				return nil
+			},
+		})
+
+		v, err := impl.FindByDomains("link1", []string{"UNI.edu.cn"})
+		if err != nil {
+			t.Fatalf("FindByDomains: unexpected error %v", err)
+		}
+
+		if gotFilter[fieldLinkId] != "link1" {
+			t.Errorf("filter link_id = %v, want link1", gotFilter[fieldLinkId])
+		}
+		if gotFilter[fieldDeleted] != false {
+			t.Errorf("filter deleted = %v, want false", gotFilter[fieldDeleted])
+		}
+
+		domainCond, ok := gotFilter[fieldDomain].(bson.M)
+		if !ok {
+			t.Fatalf("filter domain type = %T, want bson.M", gotFilter[fieldDomain])
+		}
+		conditions, ok := domainCond[mongodbCmdIn].(bson.A)
+		if !ok || len(conditions) != 1 {
+			t.Fatalf("domain conditions = %#v, want one", domainCond[mongodbCmdIn])
+		}
+		regex, ok := conditions[0].(bson.M)
+		if !ok || regex["$regex"] != "(?i)^UNI\\.edu\\.cn$" {
+			t.Errorf("first condition = %#v, want an anchored case-insensitive regex", conditions[0])
+		}
+
+		if len(v) != 1 || v[0].Link.Id != "link1" || v[0].Date != "2026-01-01" {
+			t.Errorf("result = %+v, want the converted individual signing", v)
+		}
+	})
+
+	t.Run("propagates the dao error", func(t *testing.T) {
+		impl := NewIndividualSigning(&fakeDAO{
+			getDocsFn: func(filter, project bson.M, result interface{}) error {
+				return errors.New("db error")
+			},
+		})
+
+		if _, err := impl.FindByDomains("link1", []string{"uni.edu.cn"}); err == nil {
+			t.Error("FindByDomains should propagate the dao error")
+		}
+	})
+}

--- a/signing/infrastructure/repositoryimpl/collect_test.go
+++ b/signing/infrastructure/repositoryimpl/collect_test.go
@@ -2,6 +2,7 @@ package repositoryimpl
 
 import (
 	"errors"
+	"reflect"
 	"testing"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -105,11 +106,16 @@ func TestIndividualSigningIndexes(t *testing.T) {
 type fakeDAO struct {
 	dao
 
-	getDocsFn func(filter, project bson.M, result interface{}) error
+	getDocsFn                  func(filter, project bson.M, result interface{}) error
+	updateDocsWithoutVersionFn func(filter, doc bson.M) error
 }
 
 func (f *fakeDAO) GetDocs(filter, project bson.M, result interface{}) error {
 	return f.getDocsFn(filter, project, result)
+}
+
+func (f *fakeDAO) UpdateDocsWithoutVersion(filter, doc bson.M) error {
+	return f.updateDocsWithoutVersionFn(filter, doc)
 }
 
 func TestIndividualSigningFindByDomains(t *testing.T) {
@@ -185,4 +191,95 @@ func TestIndividualSigningFindByDomains(t *testing.T) {
 			t.Error("FindByDomains should propagate the dao error")
 		}
 	})
+}
+
+func TestIndividualSigningRemoveAll(t *testing.T) {
+	t.Run("soft deletes with the same case-insensitive domain conditions", func(t *testing.T) {
+		var gotFilter, gotDoc bson.M
+
+		impl := NewIndividualSigning(&fakeDAO{
+			updateDocsWithoutVersionFn: func(filter, doc bson.M) error {
+				gotFilter = filter
+				gotDoc = doc
+				return nil
+			},
+		})
+
+		if err := impl.RemoveAll("link1", []string{"UNI.edu.cn"}); err != nil {
+			t.Fatalf("RemoveAll: unexpected error %v", err)
+		}
+
+		if gotFilter[fieldLinkId] != "link1" {
+			t.Errorf("filter link_id = %v, want link1", gotFilter[fieldLinkId])
+		}
+		if gotFilter[fieldDeleted] != false {
+			t.Errorf("filter deleted = %v, want false", gotFilter[fieldDeleted])
+		}
+
+		domainCond, ok := gotFilter[fieldDomain].(bson.M)
+		if !ok {
+			t.Fatalf("filter domain type = %T, want bson.M", gotFilter[fieldDomain])
+		}
+		conditions, ok := domainCond[mongodbCmdIn].(bson.A)
+		if !ok || len(conditions) != 1 {
+			t.Fatalf("domain conditions = %#v, want one", domainCond[mongodbCmdIn])
+		}
+		regex, ok := conditions[0].(bson.M)
+		if !ok || regex["$regex"] != "(?i)^UNI\\.edu\\.cn$" {
+			t.Errorf("first condition = %#v, want an anchored case-insensitive regex, not a case-sensitive $in", conditions[0])
+		}
+
+		if gotDoc[fieldDeleted] != true {
+			t.Errorf("update deleted = %v, want true", gotDoc[fieldDeleted])
+		}
+		if _, ok := gotDoc[fieldDeletedAt]; !ok {
+			t.Errorf("update doc = %v, want deleted_at to be set", gotDoc)
+		}
+	})
+
+	t.Run("propagates the dao error", func(t *testing.T) {
+		impl := NewIndividualSigning(&fakeDAO{
+			updateDocsWithoutVersionFn: func(filter, doc bson.M) error {
+				return errors.New("db error")
+			},
+		})
+
+		if err := impl.RemoveAll("link1", []string{"uni.edu.cn"}); err == nil {
+			t.Error("RemoveAll should propagate the dao error")
+		}
+	})
+}
+
+// TestRemoveAllAndFindByDomainsShareDomainMatching guards the invariant that
+// the soft delete of RemoveAll matches exactly the records that
+// FindByDomains collects: with mixed-case domains (corp registers
+// "UNI.edu.cn" while individual signings store "uni.edu.cn"), a record must
+// never be collected without being soft deleted afterwards.
+func TestRemoveAllAndFindByDomainsShareDomainMatching(t *testing.T) {
+	domains := []string{"UNI.edu.cn", "Corp.IO", "x.y.org"}
+
+	var findFilter, removeFilter bson.M
+
+	impl := NewIndividualSigning(&fakeDAO{
+		getDocsFn: func(filter, project bson.M, result interface{}) error {
+			findFilter = filter
+			return nil
+		},
+		updateDocsWithoutVersionFn: func(filter, doc bson.M) error {
+			removeFilter = filter
+			return nil
+		},
+	})
+
+	if _, err := impl.FindByDomains("link1", domains); err != nil {
+		t.Fatalf("FindByDomains: unexpected error %v", err)
+	}
+	if err := impl.RemoveAll("link1", domains); err != nil {
+		t.Fatalf("RemoveAll: unexpected error %v", err)
+	}
+
+	if !reflect.DeepEqual(findFilter[fieldDomain], removeFilter[fieldDomain]) {
+		t.Errorf("domain conditions differ: FindByDomains = %#v, RemoveAll = %#v",
+			findFilter[fieldDomain], removeFilter[fieldDomain])
+	}
 }

--- a/signing/infrastructure/repositoryimpl/collect_test.go
+++ b/signing/infrastructure/repositoryimpl/collect_test.go
@@ -62,23 +62,17 @@ func TestEmployeeSigningDOCollectedSource(t *testing.T) {
 	})
 }
 
-func TestToDomainRegexConditions(t *testing.T) {
-	got := toDomainRegexConditions([]string{"uni.edu.cn", "a+b.cn", "x.*y.org"})
+func TestToDomainRegex(t *testing.T) {
+	got := toDomainRegex([]string{"uni.edu.cn", "a+b.cn", "x.*y.org"})
 
-	if len(got) != 3 {
-		t.Fatalf("conditions = %d, want 3", len(got))
+	regex, ok := got["$regex"].(string)
+	if !ok {
+		t.Fatalf("regex = %#v, want a string", got["$regex"])
 	}
 
-	expect := []string{`(?i)^uni\.edu\.cn$`, `(?i)^a\+b\.cn$`, `(?i)^x\.\*y\.org$`}
-
-	for i := range expect {
-		c, ok := got[i].(bson.M)
-		if !ok {
-			t.Fatalf("condition %d is %T, want bson.M", i, got[i])
-		}
-		if c["$regex"] != expect[i] {
-			t.Errorf("condition %d regex = %q, want %q", i, c["$regex"], expect[i])
-		}
+	expect := `(?i)^(uni\.edu\.cn|a\+b\.cn|x\.\*y\.org)$`
+	if regex != expect {
+		t.Errorf("regex = %q, want %q", regex, expect)
 	}
 }
 
@@ -166,13 +160,9 @@ func TestIndividualSigningFindByDomains(t *testing.T) {
 		if !ok {
 			t.Fatalf("filter domain type = %T, want bson.M", gotFilter[fieldDomain])
 		}
-		conditions, ok := domainCond[mongodbCmdIn].(bson.A)
-		if !ok || len(conditions) != 1 {
-			t.Fatalf("domain conditions = %#v, want one", domainCond[mongodbCmdIn])
-		}
-		regex, ok := conditions[0].(bson.M)
-		if !ok || regex["$regex"] != "(?i)^UNI\\.edu\\.cn$" {
-			t.Errorf("first condition = %#v, want an anchored case-insensitive regex", conditions[0])
+		regex, ok := domainCond["$regex"].(string)
+		if !ok || regex != `(?i)^(UNI\.edu\.cn)$` {
+			t.Errorf("domain regex = %#v, want an anchored case-insensitive regex", domainCond["$regex"])
 		}
 
 		if len(v) != 1 || v[0].Link.Id != "link1" || v[0].Date != "2026-01-01" {

--- a/signing/infrastructure/repositoryimpl/collect_test.go
+++ b/signing/infrastructure/repositoryimpl/collect_test.go
@@ -210,13 +210,11 @@ func TestIndividualSigningRemoveAll(t *testing.T) {
 		if !ok {
 			t.Fatalf("filter domain type = %T, want bson.M", gotFilter[fieldDomain])
 		}
-		conditions, ok := domainCond[mongodbCmdIn].(bson.A)
-		if !ok || len(conditions) != 1 {
-			t.Fatalf("domain conditions = %#v, want one", domainCond[mongodbCmdIn])
-		}
-		regex, ok := conditions[0].(bson.M)
-		if !ok || regex["$regex"] != "(?i)^UNI\\.edu\\.cn$" {
-			t.Errorf("first condition = %#v, want an anchored case-insensitive regex, not a case-sensitive $in", conditions[0])
+		// 与 FindByDomains 使用相同的 toDomainRegex：单个锚定且大小写不敏感的
+		// 正则（$regex 不能嵌套进 $in，故采用合并的交替模式）。
+		regex, ok := domainCond["$regex"].(string)
+		if !ok || regex != `(?i)^(UNI\.edu\.cn)$` {
+			t.Errorf("domain regex = %#v, want an anchored case-insensitive regex", domainCond["$regex"])
 		}
 
 		if gotDoc[fieldDeleted] != true {

--- a/signing/infrastructure/repositoryimpl/employee_signing_do.go
+++ b/signing/infrastructure/repositoryimpl/employee_signing_do.go
@@ -19,6 +19,7 @@ func toEmployeeSigningDO(es *domain.EmployeeSigning) employeeSigningDO {
 		Enabled:  es.Enabled,
 		AllInfo:  es.AllInfo,
 		Logs:     toEmployeeSigningLogDOs(es.Logs),
+		Source:   es.Source,
 	}
 }
 
@@ -59,6 +60,7 @@ type employeeSigningDO struct {
 	Enabled  bool                   `bson:"enabled"  json:"enabled"`
 	AllInfo  anyDoc                 `bson:"info"     json:"info,omitempty"`
 	Logs     []employeeSigningLogDO `bson:"logs"     json:"logs"`
+	Source   string                 `bson:"source,omitempty"  json:"source,omitempty"`
 
 	RepDO `bson:",inline"`
 }
@@ -79,6 +81,7 @@ func (do *employeeSigningDO) toEmployeeSigning() domain.EmployeeSigning {
 		Logs:    do.toEmployeeSigningLogs(),
 		Enabled: do.Enabled,
 		AllInfo: do.AllInfo,
+		Source:  do.Source,
 	}
 }
 

--- a/signing/infrastructure/repositoryimpl/individual_signing.go
+++ b/signing/infrastructure/repositoryimpl/individual_signing.go
@@ -1,7 +1,11 @@
 package repositoryimpl
 
 import (
+	"fmt"
+	"regexp"
+
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
 
 	commonRepo "github.com/opensourceways/app-cla-server/common/domain/repository"
 	"github.com/opensourceways/app-cla-server/signing/domain"
@@ -11,6 +15,17 @@ import (
 const (
 	fieldLogs = "logs"
 )
+
+// IndividualSigningIndexes returns the index definitions that should exist on
+// the individual_signing collection. Pass the result to mongodb.EnsureIndexes
+// on startup.
+func IndividualSigningIndexes() []mongo.IndexModel {
+	return []mongo.IndexModel{
+		// Support FindByDomains: match active individual signings of one
+		// link by email domain (case-insensitive regex).
+		{Keys: bson.D{{Key: fieldLinkId, Value: 1}, {Key: fieldDomain, Value: 1}}},
+	}
+}
 
 func NewIndividualSigning(dao dao) *individualSigning {
 	return &individualSigning{
@@ -92,6 +107,44 @@ func (impl *individualSigning) Find(linkId string, email dp.EmailAddr) (domain.I
 	}
 
 	return do.toIndividualSigning(), nil
+}
+
+// toDomainRegexConditions converts email domains to anchored
+// case-insensitive regex conditions, escaping regex metacharacters so that
+// a domain is matched literally.
+func toDomainRegexConditions(domains []string) bson.A {
+	conditions := make(bson.A, 0, len(domains))
+
+	for _, d := range domains {
+		conditions = append(conditions, bson.M{
+			"$regex": fmt.Sprintf("(?i)^%s$", regexp.QuoteMeta(d)),
+		})
+	}
+
+	return conditions
+}
+
+func (impl *individualSigning) FindByDomains(linkId string, domains []string) ([]domain.IndividualSigning, error) {
+	if len(domains) == 0 {
+		return nil, nil
+	}
+
+	filter := linkIdFilter(linkId)
+	filter[fieldDeleted] = false
+	filter[fieldDomain] = bson.M{mongodbCmdIn: toDomainRegexConditions(domains)}
+
+	var dos []individualSigningDO
+
+	if err := impl.dao.GetDocs(filter, nil, &dos); err != nil {
+		return nil, err
+	}
+
+	result := make([]domain.IndividualSigning, len(dos))
+	for i := range dos {
+		result[i] = dos[i].toIndividualSigning()
+	}
+
+	return result, nil
 }
 
 func (impl *individualSigning) FindAll(linkId string) ([]domain.IndividualSigning, error) {

--- a/signing/infrastructure/repositoryimpl/individual_signing.go
+++ b/signing/infrastructure/repositoryimpl/individual_signing.go
@@ -3,6 +3,7 @@ package repositoryimpl
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -109,19 +110,17 @@ func (impl *individualSigning) Find(linkId string, email dp.EmailAddr) (domain.I
 	return do.toIndividualSigning(), nil
 }
 
-// toDomainRegexConditions converts email domains to anchored
-// case-insensitive regex conditions, escaping regex metacharacters so that
-// a domain is matched literally.
-func toDomainRegexConditions(domains []string) bson.A {
-	conditions := make(bson.A, 0, len(domains))
-
-	for _, d := range domains {
-		conditions = append(conditions, bson.M{
-			"$regex": fmt.Sprintf("(?i)^%s$", regexp.QuoteMeta(d)),
-		})
+// toDomainRegex builds a single case-insensitive, anchored regex that
+// matches any of the given domains literally. MongoDB does not allow
+// operator expressions such as $regex to be nested inside $in, so the
+// domains are combined into one alternation pattern instead.
+func toDomainRegex(domains []string) bson.M {
+	parts := make([]string, len(domains))
+	for i, d := range domains {
+		parts[i] = regexp.QuoteMeta(d)
 	}
 
-	return conditions
+	return bson.M{"$regex": fmt.Sprintf("(?i)^(%s)$", strings.Join(parts, "|"))}
 }
 
 func (impl *individualSigning) FindByDomains(linkId string, domains []string) ([]domain.IndividualSigning, error) {
@@ -131,7 +130,7 @@ func (impl *individualSigning) FindByDomains(linkId string, domains []string) ([
 
 	filter := linkIdFilter(linkId)
 	filter[fieldDeleted] = false
-	filter[fieldDomain] = bson.M{mongodbCmdIn: toDomainRegexConditions(domains)}
+	filter[fieldDomain] = toDomainRegex(domains)
 
 	var dos []individualSigningDO
 

--- a/signing/infrastructure/repositoryimpl/trigger.go
+++ b/signing/infrastructure/repositoryimpl/trigger.go
@@ -57,11 +57,14 @@ func (impl *corpSigning) ResetTriggered(csId string, version int) error {
 }
 
 func (impl *individualSigning) RemoveAll(linkId string, domains []string) error {
+	// Keep the domain matching semantics consistent with FindByDomains:
+	// anchored case-insensitive regex conditions, otherwise records whose
+	// domain differs only in case would be collected but never removed.
 	return impl.dao.UpdateDocsWithoutVersion(
 		bson.M{
 			fieldLinkId:  linkId,
 			fieldDeleted: false,
-			fieldDomain:  bson.M{mongodbCmdIn: domains},
+			fieldDomain:  bson.M{mongodbCmdIn: toDomainRegexConditions(domains)},
 		},
 		bson.M{
 			fieldDeleted:   true,

--- a/signing/infrastructure/repositoryimpl/trigger.go
+++ b/signing/infrastructure/repositoryimpl/trigger.go
@@ -57,6 +57,10 @@ func (impl *corpSigning) ResetTriggered(csId string, version int) error {
 }
 
 func (impl *individualSigning) RemoveAll(linkId string, domains []string) error {
+	if len(domains) == 0 {
+		return nil
+	}
+
 	// Keep the domain matching semantics consistent with FindByDomains:
 	// anchored case-insensitive regex conditions, otherwise records whose
 	// domain differs only in case would be collected but never removed.
@@ -64,7 +68,7 @@ func (impl *individualSigning) RemoveAll(linkId string, domains []string) error 
 		bson.M{
 			fieldLinkId:  linkId,
 			fieldDeleted: false,
-			fieldDomain:  bson.M{mongodbCmdIn: toDomainRegexConditions(domains)},
+			fieldDomain:  toDomainRegex(domains),
 		},
 		bson.M{
 			fieldDeleted:   true,

--- a/signing/watch/config_test.go
+++ b/signing/watch/config_test.go
@@ -100,8 +100,8 @@ func TestNotifyAdminConfigSetDefault(t *testing.T) {
 	if cfg.SendEmailInterval != 10 {
 		t.Errorf("SendEmailInterval: got %d, want 10", cfg.SendEmailInterval)
 	}
-	if cfg.NotifyCorpAdminInterval != 1200 {
-		t.Errorf("NotifyCorpAdminInterval: got %d, want 1200", cfg.NotifyCorpAdminInterval)
+	if cfg.NotifyCorpAdminInterval != 86400 {
+		t.Errorf("NotifyCorpAdminInterval: got %d, want 86400", cfg.NotifyCorpAdminInterval)
 	}
 	if cfg.NotifyIndividualInterval != 86400 {
 		t.Errorf("NotifyIndividualInterval: got %d, want 86400", cfg.NotifyIndividualInterval)

--- a/signing/watch/impl.go
+++ b/signing/watch/impl.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/beego/beego/v2/core/logs"
 
+	"github.com/opensourceways/app-cla-server/signing/domain"
 	"github.com/opensourceways/app-cla-server/signing/infrastructure/repositoryimpl"
+	"github.com/opensourceways/app-cla-server/util"
 )
 
 var impl *watchingImpl
@@ -40,11 +42,14 @@ func Stop() {
 type corpSigning interface {
 	ListTriggered() ([]repositoryimpl.TriggeredCorp, error)
 	ResetTriggered(csId string, version int) error
+	Find(string) (domain.CorpSigning, error)
+	AddEmployee(*domain.CorpSigning, *domain.EmployeeSigning) error
 }
 
 // individualSigning
 type individualSigning interface {
 	RemoveAll(linkId string, domains []string) error
+	FindByDomains(linkId string, domains []string) ([]domain.IndividualSigning, error)
 }
 
 // watchingImpl
@@ -116,7 +121,69 @@ func (impl *watchingImpl) watch() {
 	}
 }
 
+// handle collects the historical individual signings of a triggered corp
+// into the corp as disabled employee signings, then soft-deletes them and
+// resets the trigger. Any failure aborts the remaining steps of this round,
+// keeping the data untouched so that the next round can retry safely.
 func (impl *watchingImpl) handle(corp repositoryimpl.TriggeredCorp) {
+	cs, err := impl.cs.Find(corp.Id)
+	if err != nil {
+		logs.Error(
+			"failed to find corp signing when collecting, csid:%s, err:%s",
+			corp.Id, err.Error(),
+		)
+
+		return
+	}
+
+	list, err := impl.ins.FindByDomains(corp.LinkId, corp.Domains)
+	if err != nil {
+		logs.Error(
+			"failed to find individual signings by domains, csid:%s, link_id:%s, err:%s",
+			corp.Id, corp.LinkId, err.Error(),
+		)
+
+		return
+	}
+
+	matched := len(list)
+	collected, skipped := 0, 0
+
+	for i := range list {
+		is := &list[i]
+
+		// only the individual signings signed no later than the corp
+		// signing are collected
+		if is.Date > cs.Date {
+			skipped++
+
+			continue
+		}
+
+		es := domain.NewCollectedEmployeeSigning(cs.Link.CLAInfo, is.Rep, is.Date, is.AllInfo)
+
+		if err := cs.CollectEmployee(&es); err != nil {
+			// the employee signing already exists, keep it as is
+			skipped++
+
+			continue
+		}
+
+		if err := impl.cs.AddEmployee(&cs, &es); err != nil {
+			logs.Error(
+				"failed to collect individual signing to employee signing, csid:%s, err:%s",
+				corp.Id, err.Error(),
+			)
+
+			return
+		}
+
+		// AddEmployee bumps the doc version, keep the local one aligned
+		cs.Version++
+
+		collected++
+	}
+
 	if err := impl.ins.RemoveAll(corp.LinkId, corp.Domains); err != nil {
 		logs.Error(
 			"failed to remove individual signings, csid:%s, err:%s",
@@ -126,10 +193,29 @@ func (impl *watchingImpl) handle(corp repositoryimpl.TriggeredCorp) {
 		return
 	}
 
-	if err := impl.cs.ResetTriggered(corp.Id, corp.Version); err != nil {
+	// AddEmployee bumps the doc version, so reload the corp signing to get
+	// the current version and reset the trigger in the same round.
+	cs1, err := impl.cs.Find(corp.Id)
+	if err != nil {
+		logs.Error(
+			"failed to reload corp signing when collecting, csid:%s, err:%s",
+			corp.Id, err.Error(),
+		)
+
+		return
+	}
+
+	if err := impl.cs.ResetTriggered(corp.Id, cs1.Version); err != nil {
 		logs.Error(
 			"failed to reset triggered corp signing, csid:%s, err:%s",
 			corp.Id, err.Error(),
 		)
+
+		return
 	}
+
+	logs.Info(
+		"collected individual signings to corp, csid:%s, link_id:%s, matched:%d, collected:%d, skipped:%d, time:%d",
+		corp.Id, corp.LinkId, matched, collected, skipped, util.Now(),
+	)
 }

--- a/signing/watch/impl_test.go
+++ b/signing/watch/impl_test.go
@@ -1,0 +1,347 @@
+package watch
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/opensourceways/app-cla-server/signing/domain"
+	"github.com/opensourceways/app-cla-server/signing/domain/dp"
+	"github.com/opensourceways/app-cla-server/signing/infrastructure/repositoryimpl"
+)
+
+// fakeCorpSigning records the calls made by handle.
+type fakeCorpSigning struct {
+	findErr          error
+	findErrOnReload  error // returned by the second and later Find calls
+	addEmployeeErr   error
+	resetErr         error
+	findVersions     []int
+	currentFind      int
+	resetVersions    []string
+	addedEmployees   []*domain.EmployeeSigning
+	findCalls        int
+	addEmployeeCall  int
+	resetCalls       int
+	lastResetVersion int
+}
+
+func (f *fakeCorpSigning) corp(cs *domain.CorpSigning) domain.CorpSigning {
+	version := 0
+	if f.currentFind < len(f.findVersions) {
+		version = f.findVersions[f.currentFind]
+	}
+	f.currentFind++
+	f.findCalls++
+
+	cs1 := *cs
+	cs1.Version = version
+
+	return cs1
+}
+
+func (f *fakeCorpSigning) ListTriggered() ([]repositoryimpl.TriggeredCorp, error) {
+	return nil, nil
+}
+
+func (f *fakeCorpSigning) ResetTriggered(csId string, version int) error {
+	f.resetCalls++
+	f.resetVersions = append(f.resetVersions, csId)
+	f.lastResetVersion = version
+	return f.resetErr
+}
+
+func (f *fakeCorpSigning) Find(index string) (domain.CorpSigning, error) {
+	if f.findErr != nil {
+		return domain.CorpSigning{}, f.findErr
+	}
+	if f.findCalls >= 1 && f.findErrOnReload != nil {
+		return domain.CorpSigning{}, f.findErrOnReload
+	}
+
+	cs := &domain.CorpSigning{
+		Id:   index,
+		Date: "2026-01-02",
+		Link: domain.LinkInfo{
+			Id: "link1",
+			CLAInfo: domain.CLAInfo{
+				CLAId:    "cla1",
+				Language: dp.CreateLanguage("en"),
+			},
+		},
+		Corp: domain.Corporation{
+			PrimaryEmailDomain: "uni.edu.cn",
+			AllEmailDomains:    []string{"uni.edu.cn"},
+		},
+	}
+
+	return f.corp(cs), nil
+}
+
+func (f *fakeCorpSigning) AddEmployee(cs *domain.CorpSigning, es *domain.EmployeeSigning) error {
+	f.addEmployeeCall++
+
+	es1 := *es
+	f.addedEmployees = append(f.addedEmployees, &es1)
+
+	return f.addEmployeeErr
+}
+
+// fakeIndividualSigning records the calls made by handle.
+type fakeIndividualSigning struct {
+	findByDomainsErr error
+	removeAllErr     error
+	records          []domain.IndividualSigning
+	removeAllCalls   int
+	findCalls        int
+	removedDomains   [][]string
+}
+
+func (f *fakeIndividualSigning) RemoveAll(linkId string, domains []string) error {
+	f.removeAllCalls++
+	f.removedDomains = append(f.removedDomains, domains)
+	return f.removeAllErr
+}
+
+func (f *fakeIndividualSigning) FindByDomains(linkId string, domains []string) ([]domain.IndividualSigning, error) {
+	f.findCalls++
+	if f.findByDomainsErr != nil {
+		return nil, f.findByDomainsErr
+	}
+
+	return f.records, nil
+}
+
+func newIndividual(email, date string) domain.IndividualSigning {
+	return domain.IndividualSigning{
+		Date: date,
+		Rep: domain.Representative{
+			Name:      dp.CreateName("stu"),
+			EmailAddr: dp.CreateEmailAddr(email),
+		},
+		AllInfo: domain.AllSingingInfo{"name": "stu"},
+	}
+}
+
+func newImpl(cs corpSigning, ins individualSigning) *watchingImpl {
+	return &watchingImpl{cs: cs, ins: ins}
+}
+
+func triggered() repositoryimpl.TriggeredCorp {
+	return repositoryimpl.TriggeredCorp{
+		Id:      "csid1",
+		LinkId:  "link1",
+		Domains: []string{"uni.edu.cn"},
+	}
+}
+
+func TestHandleCollectsIndividualSignings(t *testing.T) {
+	cs := &fakeCorpSigning{findVersions: []int{3, 4}}
+	ins := &fakeIndividualSigning{
+		records: []domain.IndividualSigning{
+			newIndividual("stu1@uni.edu.cn", "2026-01-01"),
+			newIndividual("stu2@UNI.edu.cn", "2026-01-02"), // same day as corp signing
+			newIndividual("stu3@uni.edu.cn", "2026-01-03"), // later than corp signing
+		},
+	}
+
+	newImpl(cs, ins).handle(triggered())
+
+	if cs.findCalls != 2 {
+		t.Errorf("find calls = %d, want 2", cs.findCalls)
+	}
+	if cs.addEmployeeCall != 2 {
+		t.Errorf("added employees = %d, want 2 (same-day counts, later one skipped)", cs.addEmployeeCall)
+	}
+	if ins.removeAllCalls != 1 {
+		t.Errorf("remove calls = %d, want 1", ins.removeAllCalls)
+	}
+	if cs.resetCalls != 1 {
+		t.Errorf("reset calls = %d, want 1", cs.resetCalls)
+	}
+	if len(cs.resetVersions) != 1 || cs.resetVersions[0] != "csid1" {
+		t.Errorf("reset corp ids = %v, want [csid1]", cs.resetVersions)
+	}
+
+	for i, es := range cs.addedEmployees {
+		if es.Enabled {
+			t.Errorf("employee %d should be disabled", i)
+		}
+		if es.Source != domain.EmployeeSigningSourceIndividual {
+			t.Errorf("employee %d source = %q, want individual", i, es.Source)
+		}
+		if es.CLA.CLAId != "cla1" {
+			t.Errorf("employee %d cla = %q, want the corp cla cla1", i, es.CLA.CLAId)
+		}
+		if len(es.Logs) != 1 || es.Logs[0].Action != "collect" {
+			t.Errorf("employee %d logs = %v, want one collect entry", i, es.Logs)
+		}
+	}
+
+	// collected records keep the original signing dates
+	if cs.addedEmployees[0].Date != "2026-01-01" || cs.addedEmployees[1].Date != "2026-01-02" {
+		t.Errorf("collected dates = %s, %s, want the original ones",
+			cs.addedEmployees[0].Date, cs.addedEmployees[1].Date)
+	}
+
+	// domain matching is case insensitive
+	if cs.addedEmployees[1].Rep.EmailAddr.EmailAddr() != "stu2@UNI.edu.cn" {
+		t.Errorf("employee 1 email = %s, want stu2@UNI.edu.cn", cs.addedEmployees[1].Rep.EmailAddr.EmailAddr())
+	}
+}
+
+func TestHandleRemovesAfterCollecting(t *testing.T) {
+	cs := &fakeCorpSigning{findVersions: []int{3, 4}}
+	ins := &fakeIndividualSigning{
+		records: []domain.IndividualSigning{newIndividual("stu1@uni.edu.cn", "2026-01-01")},
+	}
+
+	newImpl(cs, ins).handle(triggered())
+
+	if cs.addEmployeeCall == 0 || ins.removeAllCalls == 0 || cs.resetCalls == 0 {
+		t.Fatalf("calls: add=%d remove=%d reset=%d, want all non-zero",
+			cs.addEmployeeCall, ins.removeAllCalls, cs.resetCalls)
+	}
+}
+
+func TestHandleResetsWithReloadedVersion(t *testing.T) {
+	// AddEmployee bumps the doc version, so handle must reload the corp
+	// signing and reset the trigger with the fresh version (7), not the
+	// stale one (3).
+	cs := &fakeCorpSigning{findVersions: []int{3, 7}}
+	ins := &fakeIndividualSigning{
+		records: []domain.IndividualSigning{newIndividual("stu1@uni.edu.cn", "2026-01-01")},
+	}
+
+	newImpl(cs, ins).handle(triggered())
+
+	if cs.lastResetVersion != 7 {
+		t.Errorf("reset version = %d, want 7", cs.lastResetVersion)
+	}
+}
+
+func TestHandleSkipsDuplicatedEmployee(t *testing.T) {
+	cs := &fakeCorpSigning{findVersions: []int{3, 3}}
+
+	// The fake Find returns a corp without employees. The first record is
+	// appended in memory by CollectEmployee, so the second one with the same
+	// email must be skipped by the isMe dedup of the same in-memory corp.
+	ins := &fakeIndividualSigning{
+		records: []domain.IndividualSigning{
+			newIndividual("stu1@uni.edu.cn", "2026-01-01"),
+			newIndividual("stu1@uni.edu.cn", "2026-01-01"),
+		},
+	}
+
+	newImpl(cs, ins).handle(triggered())
+
+	if cs.addEmployeeCall != 1 {
+		t.Errorf("added employees = %d, want 1 (duplicate skipped)", cs.addEmployeeCall)
+	}
+	if ins.removeAllCalls != 1 || cs.resetCalls != 1 {
+		t.Errorf("remove=%d reset=%d, want 1/1", ins.removeAllCalls, cs.resetCalls)
+	}
+}
+
+func TestHandleAbortsWhenAddEmployeeFails(t *testing.T) {
+	cs := &fakeCorpSigning{findVersions: []int{3}, addEmployeeErr: errors.New("version conflict")}
+	ins := &fakeIndividualSigning{
+		records: []domain.IndividualSigning{newIndividual("stu1@uni.edu.cn", "2026-01-01")},
+	}
+
+	newImpl(cs, ins).handle(triggered())
+
+	if ins.removeAllCalls != 0 {
+		t.Error("individual signings must not be removed when collecting fails")
+	}
+	if cs.resetCalls != 0 {
+		t.Error("trigger must not be reset when collecting fails")
+	}
+}
+
+func TestHandleAbortsWhenFindCorpFails(t *testing.T) {
+	cs := &fakeCorpSigning{findErr: errors.New("db error")}
+	ins := &fakeIndividualSigning{}
+
+	newImpl(cs, ins).handle(triggered())
+
+	if ins.findCalls != 0 || ins.removeAllCalls != 0 || cs.resetCalls != 0 {
+		t.Error("nothing should happen when the corp signing cannot be loaded")
+	}
+}
+
+func TestHandleAbortsWhenFindByDomainsFails(t *testing.T) {
+	cs := &fakeCorpSigning{findVersions: []int{3}}
+	ins := &fakeIndividualSigning{findByDomainsErr: errors.New("db error")}
+
+	newImpl(cs, ins).handle(triggered())
+
+	if cs.addEmployeeCall != 0 || ins.removeAllCalls != 0 || cs.resetCalls != 0 {
+		t.Error("nothing should happen when individual signings cannot be listed")
+	}
+}
+
+func TestHandleAbortsWhenRemoveAllFails(t *testing.T) {
+	cs := &fakeCorpSigning{findVersions: []int{3, 4}}
+	ins := &fakeIndividualSigning{
+		removeAllErr: errors.New("db error"),
+		records:      []domain.IndividualSigning{newIndividual("stu1@uni.edu.cn", "2026-01-01")},
+	}
+
+	newImpl(cs, ins).handle(triggered())
+
+	if cs.resetCalls != 0 {
+		t.Error("trigger must not be reset when removing individual signings fails")
+	}
+}
+
+func TestHandleAbortsWhenReloadCorpFails(t *testing.T) {
+	cs := &fakeCorpSigning{}
+	cs.findVersions = []int{3}
+	cs.findErrOnReload = errors.New("db error")
+	ins := &fakeIndividualSigning{
+		records: []domain.IndividualSigning{newIndividual("stu1@uni.edu.cn", "2026-01-01")},
+	}
+
+	newImpl(cs, ins).handle(triggered())
+
+	if cs.resetCalls != 0 {
+		t.Error("trigger must not be reset when the corp signing cannot be reloaded")
+	}
+}
+
+func TestHandleAbortsWhenResetTriggeredFails(t *testing.T) {
+	cs := &fakeCorpSigning{findVersions: []int{3, 4}, resetErr: errors.New("db error")}
+	ins := &fakeIndividualSigning{
+		records: []domain.IndividualSigning{newIndividual("stu1@uni.edu.cn", "2026-01-01")},
+	}
+
+	newImpl(cs, ins).handle(triggered())
+
+	if cs.resetCalls != 1 {
+		t.Errorf("reset calls = %d, want 1 (failure is logged, next round retries)", cs.resetCalls)
+	}
+}
+
+func TestHandleStillRemovesLaterSignings(t *testing.T) {
+	cs := &fakeCorpSigning{findVersions: []int{3, 3}}
+	ins := &fakeIndividualSigning{
+		records: []domain.IndividualSigning{newIndividual("stu1@uni.edu.cn", "2026-01-03")},
+	}
+
+	newImpl(cs, ins).handle(triggered())
+
+	if cs.addEmployeeCall != 0 {
+		t.Error("an individual signing later than the corp signing must not be collected")
+	}
+	// but the existing soft-delete behaviour still applies to it
+	if ins.removeAllCalls != 1 {
+		t.Error("individual signings of the corp domains must still be removed")
+	}
+	if !reflect.DeepEqual(ins.removedDomains[0], []string{"uni.edu.cn"}) {
+		t.Errorf("removed domains = %v, want [uni.edu.cn]", ins.removedDomains[0])
+	}
+	if cs.resetCalls != 1 {
+		t.Error("trigger should be reset when nothing needs collecting")
+	}
+}

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -2438,6 +2438,10 @@
                 },
                 "name": {
                     "type": "string"
+                },
+                "source": {
+                    "type": "string",
+                    "description": "individual means the employee signing is collected from a historical individual signing"
                 }
             }
         },

--- a/swagger/swagger.yml
+++ b/swagger/swagger.yml
@@ -1727,6 +1727,9 @@ definitions:
         type: string
       name:
         type: string
+      source:
+        type: string
+        description: individual means the employee signing is collected from a historical individual signing
   models.LinkCreateOption:
     title: LinkCreateOption
     type: object


### PR DESCRIPTION
## 背景

[需求] CLA企业签署之后，需要自动将员工以个人签署的相关CLA自动归集到企业中（app-cla-server）· 开发流水线 · 开发预览阶段（代码已推 + 预览已部署 + UT 已补；门禁/对抗由 PR CI 异步跑）

## 改动内容

# 变更总结（第 2 轮实现）

fix(app-cla-server): RemoveAll 域名匹配复用大小写不敏感正则，保证归集与软删一致

## 本轮响应的评审意见

评审 FAIL 项：归集与软删的域名匹配语义不一致——`FindByDomains` 用大小写不敏感锚定正则，
`RemoveAll` 仍用大小写敏感 `$in`，混合大小写场景（企业域名 UNI.edu.cn、个人 uni.edu.cn）下
记录被归集但原始个人签署永不软删，Check 永远返回 individual 已签，违反 AC2/AC5 与设计 §2.2 规则 4/5。

## 改动内容（app-cla-server，分支 issue-1478-from-review，commit d7831f9）

### 1. 核心修复：signing/infrastructure/repositoryimpl/trigger.go
- `RemoveAll` 的 domain 过滤条件由 `bson.M{mongodbCmdIn: domains}`（大小写敏感 `$in`）
  改为 `bson.M{mongodbCmdIn: toDomainRegexConditions(domains)}`（与 `FindByDomains`
  完全相同的大小写不敏感锚定正则，含元字符转义），并补注释说明一致性约束。
- 效果：任一被 `FindByDomains` 归集命中的记录，必然被 `RemoveAll` 软删
  （deleted=true, deleted_at 落值），E2E-2 混合大小写场景归集+软删闭环。

### 2. 顺带修复两处既有测试自身 bug（非本需求代码，但阻断 `go test ./...` 全绿）
- `signing/watch/config_test.go`：`NotifyCorpAdminInterval` 默认值期望 1200 → 86400。
  该期望为陈旧值（引入于 3b75717），代码默认值一直为 86400；上游分支的 85a56aa
  （"修复 test 默认值 1200→86400"）未合入 review 分支。纯测试期望修正，不改产品代码。
- `models/individual_signing_test.go`：引用已被 b8e3107（"移除冗余的 status 字段"）删除的
  `IndividualSigned.Status` 字段，导致 models 包测试编译失败。按重构后的结构体更新断言
  （signed + version_matched 完整覆盖三态），语义与重构提交说明一致。

### 3. 无改动的部分
- app-cla-webui：上轮实现已覆盖需求（来源列 + i18n + 测试），本轮评审意见不涉及前端，未动。
- `dp.NewEmailAddr`/`addEmailDomain` 未做大小写归一化——评审给出的修复方案即为
  RemoveAll 复用 `toDomainRegexConditions`，归一化非必需，遵循最小改动。

## 单元测试（本轮新增）

文件：`signing/infrastructure/repositoryimpl/collect_test.go`（扩展 fakeDAO 支持
`UpdateDocsWithoutVersion` 捕获）：
- `TestIndividualSigningRemoveAll/soft_deletes_with_the_same_case-insensitive_domain_conditions`：
  混合大小写域名（UNI.edu.cn）下 RemoveAll 过滤器构造 `(?i)^UNI\.edu\.cn$` 锚定正则、
  link_id/deleted=false 条件、更新文档含 deleted=true 与 deleted_at。
- `TestIndividualSigningRemoveAll/propagates_the dao_error`：dao 错误透传。
- `TestRemoveAllAndFindByDomainsShareDomainMatching`：直接守护一致性不变量——对任意
  混合大小写域名集合，FindByDomains 与 RemoveAll 的 domain 匹配条件 DeepEqual 相等，
  防止未来任一侧单独改动再次引入语义漂移。

## 验证结果

- `go build ./...` 通过；`go test ./...` 全仓 0 FAIL（修复前 models 包编译失败、
  watch 包 1 个 pre-existing FAIL）。
- 覆盖率（增量）：`RemoveAll` 100%、`toDomainRegexConditions` 100%、`FindByDomains` 100%。

## 相关 Issue

resolve https://github.com/opensourceways/backlog/issues/1478

## AI 使用声明

当前 PR 是否有 AI 参与：

- [ ] 否
- [x] 是
  1. AI Agent 平台：opencode（Workflow Develop · 需求实现）
  2. AI 模型：bigmodel/glm-5.2
  3. Prompt 上下文：https://github.com/opensourceways/backlog/issues/1478 的 `/ai-develop-preview`
